### PR TITLE
Switch NuGet publishing to trusted publishing

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   modularpipeline:
@@ -33,11 +34,18 @@ jobs:
           dotnet-version: |
             9.0.x
             10.0.x
+      - name: NuGet login
+        if: ${{ github.ref == 'refs/heads/main' && github.event.inputs.publish-packages == 'true' }}
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Run Pipeline
         run: dotnet run -c Release
         working-directory: "AsyncSemaphore.Pipeline"
         env:
           DOTNET_ENVIRONMENT: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Development' }}
-          NuGet__ApiKey: ${{ github.ref == 'refs/heads/main' && secrets.NUGET__APIKEY || null }}
+          NuGet__ApiKey: ${{ steps.login.outputs.NUGET_API_KEY }}
           PULL_REQUEST_BRANCH: ${{ github.event.pull_request.head.ref }}
           PUBLISH_PACKAGES: ${{ github.event.inputs.publish-packages }}


### PR DESCRIPTION
## Summary
- request GitHub OIDC tokens for NuGet trusted publishing
- use NuGet/login@v1 with ${{ secrets.NUGET_USER }} to exchange for a short-lived NuGet API key
- pass steps.login.outputs.NUGET_API_KEY into the existing publish step or pipeline input

## Validation
- parsed the modified workflow YAML files locally
- ran git diff --check

## Follow-up
A matching trusted publishing policy must be configured on nuget.org for this repository and workflow file before the next publish run.