### PR TITLE
Rewrite core as lock-free semaphore, beating SemaphoreSlim

### DIFF
--- a/AsyncSemaphore.Benchmark/AbBenchmarks.cs
+++ b/AsyncSemaphore.Benchmark/AbBenchmarks.cs
@@ -1,0 +1,192 @@
+using AsyncSemaphore.Benchmark.Baseline;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+
+namespace AsyncSemaphore.Benchmark;
+
+/// <summary>
+/// Same-run A/B of a frozen snapshot of the core (<see cref="BaselineAsyncSemaphore"/>, commit 66ad5f7)
+/// against the working-tree core, so a change can be measured without cross-run noise.
+/// Run with <c>--filter "*AbBenchmarks*"</c>.
+/// </summary>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class AbBenchmarks
+{
+    private const int HandoffOperations = 1_000;
+    private const int ParallelWorkers = 4;
+    private const int ParallelOperationsPerWorker = 250;
+
+    private static readonly TimeSpan LongTimeout = TimeSpan.FromMinutes(5);
+
+    private readonly BaselineAsyncSemaphore _old = new(1);
+    private readonly Semaphores.AsyncSemaphore _new = new(1);
+    private readonly CancellationTokenSource _cts = new();
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Uncontended")]
+    public async Task Old_Uncontended()
+    {
+        using var _ = await _old.WaitAsync();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Uncontended")]
+    public async Task New_Uncontended()
+    {
+        using var _ = await _new.WaitAsync();
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("TimeoutUncontended")]
+    public async Task Old_TimeoutUncontended()
+    {
+        using var _ = await _old.WaitAsync(LongTimeout);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("TimeoutUncontended")]
+    public async Task New_TimeoutUncontended()
+    {
+        using var _ = await _new.WaitAsync(LongTimeout);
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("TokenUncontended")]
+    public async Task Old_TokenUncontended()
+    {
+        using var _ = await _old.WaitAsync(_cts.Token);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("TokenUncontended")]
+    public async Task New_TokenUncontended()
+    {
+        using var _ = await _new.WaitAsync(_cts.Token);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("AsyncHandoff")]
+    public async Task Old_AsyncHandoff()
+    {
+        var holder = await _old.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _old.WaitAsync();
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("AsyncHandoff")]
+    public async Task New_AsyncHandoff()
+    {
+        var holder = await _new.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _new.WaitAsync();
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("TimeoutHandoff")]
+    public async Task Old_TimeoutHandoff()
+    {
+        var holder = await _old.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _old.WaitAsync(LongTimeout);
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("TimeoutHandoff")]
+    public async Task New_TimeoutHandoff()
+    {
+        var holder = await _new.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _new.WaitAsync(LongTimeout);
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("TokenHandoff")]
+    public async Task Old_TokenHandoff()
+    {
+        var holder = await _old.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _old.WaitAsync(_cts.Token);
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("TokenHandoff")]
+    public async Task New_TokenHandoff()
+    {
+        var holder = await _new.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _new.WaitAsync(_cts.Token);
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = ParallelWorkers * ParallelOperationsPerWorker)]
+    [BenchmarkCategory("Parallel")]
+    public Task Old_Parallel()
+    {
+        return Task.WhenAll(Enumerable.Range(0, ParallelWorkers).Select(async _ =>
+        {
+            for (var i = 0; i < ParallelOperationsPerWorker; i++)
+            {
+                using var @lock = await _old.WaitAsync();
+                await Task.Yield();
+            }
+        }));
+    }
+
+    [Benchmark(OperationsPerInvoke = ParallelWorkers * ParallelOperationsPerWorker)]
+    [BenchmarkCategory("Parallel")]
+    public Task New_Parallel()
+    {
+        return Task.WhenAll(Enumerable.Range(0, ParallelWorkers).Select(async _ =>
+        {
+            for (var i = 0; i < ParallelOperationsPerWorker; i++)
+            {
+                using var @lock = await _new.WaitAsync();
+                await Task.Yield();
+            }
+        }));
+    }
+}

--- a/AsyncSemaphore.Benchmark/AsyncSemaphore.Benchmark.csproj
+++ b/AsyncSemaphore.Benchmark/AsyncSemaphore.Benchmark.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+      <PackageReference Include="Reservoir" Version="1.5.0" />
     </ItemGroup>
 
 </Project>

--- a/AsyncSemaphore.Benchmark/Baseline/BaselineAsyncSemaphore.cs
+++ b/AsyncSemaphore.Benchmark/Baseline/BaselineAsyncSemaphore.cs
@@ -4,19 +4,15 @@ using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks.Sources;
 
-namespace Semaphores;
+namespace AsyncSemaphore.Benchmark.Baseline;
 
-public sealed class AsyncSemaphore : IAsyncSemaphore
+/// <summary>
+/// Frozen snapshot of the core as of commit 66ad5f7 (lock-free rewrite, before the micro-optimisation
+/// pass), kept so <see cref="AbBenchmarks"/> can A/B the working-tree core against a fixed reference
+/// in the same run. Do not edit; regenerate from a newer commit if a new baseline is wanted.
+/// </summary>
+public sealed class BaselineAsyncSemaphore
 {
-    /// <summary>
-    /// Smallest tick count whose (truncated) millisecond value is -1, i.e. the lowest timeout
-    /// <see cref="SemaphoreSlim"/> accepts.
-    /// </summary>
-    private const long MinTimeoutTicks = -(2 * TimeSpan.TicksPerMillisecond) + 1;
-
-    /// <summary>Largest tick count whose (truncated) millisecond value still fits in an <see cref="int"/>.</summary>
-    private const long MaxTimeoutTicks = ((int.MaxValue + 1L) * TimeSpan.TicksPerMillisecond) - 1;
-
     /// <summary>
     /// Positive values are available permits. Negative values are outstanding waiters
     /// (each of which has enqueued, or is committed to enqueueing, a node in <see cref="_waiters"/>).
@@ -39,7 +35,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
     private bool _disposed;
 
-    public AsyncSemaphore(int maxCount)
+    public BaselineAsyncSemaphore(int maxCount)
     {
         if (maxCount < 1)
         {
@@ -49,45 +45,41 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         _count = maxCount;
     }
 
-    /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ValueTask<AsyncSemaphoreReleaser> WaitAsync()
+    public ValueTask<BaselineReleaser> WaitAsync()
     {
         ThrowIfDisposed();
 
         if (TryAcquireFast())
         {
-            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
+            return new ValueTask<BaselineReleaser>(new BaselineReleaser(this));
         }
 
         return EnqueueWaiter(Timeout.InfiniteTimeSpan, default);
     }
 
-    /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ValueTask<AsyncSemaphoreReleaser> WaitAsync(TimeSpan timeout)
+    public ValueTask<BaselineReleaser> WaitAsync(TimeSpan timeout)
     {
         return WaitAsync(timeout, CancellationToken.None);
     }
 
-    /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ValueTask<AsyncSemaphoreReleaser> WaitAsync(CancellationToken cancellationToken)
+    public ValueTask<BaselineReleaser> WaitAsync(CancellationToken cancellationToken)
     {
         ThrowIfDisposed();
         cancellationToken.ThrowIfCancellationRequested();
 
         if (TryAcquireFast())
         {
-            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
+            return new ValueTask<BaselineReleaser>(new BaselineReleaser(this));
         }
 
         return EnqueueWaiter(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 
-    /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ValueTask<AsyncSemaphoreReleaser> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken)
+    public ValueTask<BaselineReleaser> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken)
     {
         ThrowIfDisposed();
         ValidateTimeout(timeout);
@@ -95,14 +87,14 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
         if (TryAcquireFast())
         {
-            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
+            return new ValueTask<BaselineReleaser>(new BaselineReleaser(this));
         }
 
         if (timeout == TimeSpan.Zero)
         {
             // A zero timeout is a single attempt: fail here without renting a node, arming a timer,
             // or creating waiter debt that a concurrent releaser would have to spin on and settle.
-            return TimedOut(timeout);
+            return new ValueTask<BaselineReleaser>(Task.FromException<BaselineReleaser>(CreateTimeoutException(timeout)));
         }
 
         return EnqueueWaiter(timeout, cancellationToken);
@@ -133,7 +125,6 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         return false;
     }
 
-    /// <inheritdoc />
     public int CurrentCount
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -144,16 +135,14 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         }
     }
 
-    /// <inheritdoc />
     public void Dispose()
     {
         _disposed = true;
     }
 
     /// <summary>
-    /// Returns a permit. Called exactly once per successful acquisition, by <see cref="AsyncSemaphoreReleaser.Dispose"/>.
+    /// Returns a permit. Called exactly once per successful acquisition, by <see cref="BaselineReleaser.Dispose"/>.
     /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void Release()
     {
         if (Interlocked.Increment(ref _count) <= 0)
@@ -195,23 +184,33 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         }
     }
 
-    private ValueTask<AsyncSemaphoreReleaser> EnqueueWaiter(TimeSpan timeout, CancellationToken cancellationToken)
+    private ValueTask<BaselineReleaser> EnqueueWaiter(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        // The node is rented up front so the decrement-to-enqueue window a releaser spin-waits on
-        // stays as small as possible.
-        var waiter = RentWaiter();
-        var version = waiter.Version;
+        var waiter = t_pooledWaiter;
 
-        // The decrement is the commit point: a permit may have appeared since the fast path failed.
-        if (Interlocked.Decrement(ref _count) >= 0)
+        if (waiter is not null)
         {
-            // Never owned or armed, still clean.
-            ReturnWaiter(waiter);
-
-            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
+            t_pooledWaiter = null;
+        }
+        else if ((waiter = Interlocked.Exchange(ref _pooledWaiter, null)) is null && !_pool.TryDequeue(out waiter))
+        {
+            waiter = new Waiter();
         }
 
         waiter.SetOwner(this);
+
+        var version = waiter.Version;
+
+        // The decrement is the commit point: a permit may have appeared since the fast path failed.
+        // The node is rented up front so the decrement-to-enqueue window a releaser spin-waits on
+        // stays as small as possible.
+        if (Interlocked.Decrement(ref _count) >= 0)
+        {
+            // Never armed, still clean.
+            ReturnWaiter(waiter);
+
+            return new ValueTask<BaselineReleaser>(new BaselineReleaser(this));
+        }
 
         // Arm cancellation before enqueueing: a claim can only happen after the enqueue, so the
         // claimer always observes fully-armed timer/registration fields when cleaning them up.
@@ -223,29 +222,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
         _waiters.Enqueue(waiter);
 
-        return new ValueTask<AsyncSemaphoreReleaser>(waiter, version);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private Waiter RentWaiter()
-    {
-        var waiter = t_pooledWaiter;
-
-        if (waiter is not null)
-        {
-            t_pooledWaiter = null;
-
-            return waiter;
-        }
-
-        // Test before exchanging so an empty slot costs a read, not a locked write on a shared line.
-        if (Volatile.Read(ref _pooledWaiter) is not null
-            && (waiter = Interlocked.Exchange(ref _pooledWaiter, null)) is not null)
-        {
-            return waiter;
-        }
-
-        return _pool.TryDequeue(out waiter) ? waiter : new Waiter();
+        return new ValueTask<BaselineReleaser>(waiter, version);
     }
 
     private void ReturnWaiter(Waiter waiter)
@@ -259,9 +236,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
             return;
         }
 
-        // Test before the CAS so a full slot costs a read, not a failed locked write.
-        if (Volatile.Read(ref _pooledWaiter) is not null
-            || Interlocked.CompareExchange(ref _pooledWaiter, waiter, null) is not null)
+        if (Interlocked.CompareExchange(ref _pooledWaiter, waiter, null) != null)
         {
             _pool.Enqueue(waiter);
         }
@@ -272,41 +247,18 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
     {
         if (_disposed)
         {
-            ThrowObjectDisposed();
+            throw new ObjectDisposedException(nameof(BaselineAsyncSemaphore));
         }
     }
 
-    /// <summary>
-    /// Same contract as <see cref="SemaphoreSlim"/> (<c>(long)timeout.TotalMilliseconds</c> must lie in
-    /// [-1, <see cref="int.MaxValue"/>]) as a single unsigned range compare on the raw ticks, which
-    /// avoids the floating-point conversion on every timed wait.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void ValidateTimeout(TimeSpan timeout)
     {
-        if (unchecked((ulong)(timeout.Ticks - MinTimeoutTicks)) > unchecked((ulong)(MaxTimeoutTicks - MinTimeoutTicks)))
+        var totalMilliseconds = (long)timeout.TotalMilliseconds;
+
+        if (totalMilliseconds < Timeout.Infinite || totalMilliseconds > int.MaxValue)
         {
-            ThrowTimeoutOutOfRange(timeout);
+            throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "The timeout must be -1 milliseconds (infinite) or a non-negative value <= Int32.MaxValue milliseconds.");
         }
-    }
-
-    // Throw and fault helpers are kept out of line so the inlined fast paths stay small.
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void ThrowObjectDisposed()
-    {
-        throw new ObjectDisposedException(nameof(AsyncSemaphore));
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void ThrowTimeoutOutOfRange(TimeSpan timeout)
-    {
-        throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "The timeout must be -1 milliseconds (infinite) or a non-negative value <= Int32.MaxValue milliseconds.");
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static ValueTask<AsyncSemaphoreReleaser> TimedOut(TimeSpan timeout)
-    {
-        return new ValueTask<AsyncSemaphoreReleaser>(Task.FromException<AsyncSemaphoreReleaser>(CreateTimeoutException(timeout)));
     }
 
     private static TimeoutException CreateTimeoutException(TimeSpan timeout)
@@ -314,7 +266,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         return new TimeoutException($"The semaphore wait exceeded the timeout of {timeout}.");
     }
 
-    private sealed class Waiter : IValueTaskSource<AsyncSemaphoreReleaser>
+    private sealed class Waiter : IValueTaskSource<BaselineReleaser>
     {
         private const int StatePending = 0;
         private const int StateClaimed = 1;
@@ -323,9 +275,9 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         private static readonly TimerCallback TimeoutCallback = static state => OnTimeout((Waiter)state!);
         private static readonly Action<object?> CancellationCallback = static state => OnCancelled((Waiter)state!);
 
-        private AsyncSemaphore _owner = null!;
+        private BaselineAsyncSemaphore _owner = null!;
 
-        private ManualResetValueTaskSourceCore<AsyncSemaphoreReleaser> _core;
+        private ManualResetValueTaskSourceCore<BaselineReleaser> _core;
         private int _state;
         private bool _cancellable;
         private Timer? _timeoutTimer;
@@ -345,7 +297,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void SetOwner(AsyncSemaphore owner)
+        public void SetOwner(BaselineAsyncSemaphore owner)
         {
             _owner = owner;
         }
@@ -370,26 +322,10 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
             {
                 // The cancellation callbacks lose the CAS and return immediately, so these cannot deadlock.
                 _cancellationRegistration.Dispose();
-
-                var timer = _timeoutTimer;
-
-                if (timer is not null)
-                {
-#if NETSTANDARD2_0
-                    timer.Dispose();
-#else
-                    // DisposeAsync completes synchronously only when no callback is in flight (it checks
-                    // the callback count under the same lock Fire takes before running one), which proves
-                    // no stale OnTimeout can ever touch this node again, so it is safe to pool.
-                    if (timer.DisposeAsync().IsCompletedSuccessfully)
-                    {
-                        _timeoutTimer = null;
-                    }
-#endif
-                }
+                _timeoutTimer?.Dispose();
             }
 
-            _core.SetResult(new AsyncSemaphoreReleaser(_owner));
+            _core.SetResult(new BaselineReleaser(_owner));
         }
 
         public void ArmCancellation(TimeSpan timeout, CancellationToken cancellationToken)
@@ -400,19 +336,12 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
             if (cancellationToken.CanBeCanceled)
             {
-#if NETSTANDARD2_0
                 _cancellationRegistration = cancellationToken.Register(CancellationCallback, this);
-#else
-                // The callback only performs a CAS and completes the core, so it needs no ExecutionContext.
-                _cancellationRegistration = cancellationToken.UnsafeRegister(CancellationCallback, this);
-#endif
             }
 
             if (timeout != Timeout.InfiniteTimeSpan && Volatile.Read(ref _state) == StatePending)
             {
-                // Integer milliseconds (already validated to fit) so the Timer constructor skips its own
-                // floating-point TimeSpan conversion.
-                var timer = new Timer(TimeoutCallback, this, (int)(timeout.Ticks / TimeSpan.TicksPerMillisecond), Timeout.Infinite);
+                var timer = new Timer(TimeoutCallback, this, timeout, Timeout.InfiniteTimeSpan);
 
                 _timeoutTimer = timer;
 
@@ -449,7 +378,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
             waiter._core.SetException(new OperationCanceledException(waiter._cancellationToken));
         }
 
-        public AsyncSemaphoreReleaser GetResult(short token)
+        public BaselineReleaser GetResult(short token)
         {
             // Throws for cancelled/timed-out waiters, which must not be pooled:
             // their node is still queued until a release dequeues and settles it.
@@ -457,10 +386,10 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
             if (_timeoutTimer is not null)
             {
-                // A timer callback was in flight when the claimer disposed the timer (Timer.Dispose
-                // does not wait for it, unlike CancellationTokenRegistration.Dispose), so a stale
-                // OnTimeout may still hold this node. Dropping it instead of pooling leaves _state
-                // at StateClaimed, so the stale CAS fails without touching a recycled core.
+                // Timer.Dispose does not wait for an in-flight callback (unlike
+                // CancellationTokenRegistration.Dispose), so a stale OnTimeout may still
+                // hold this node. Dropping it instead of pooling leaves _state at
+                // StateClaimed, so the stale CAS fails without touching a recycled core.
                 return result;
             }
 

--- a/AsyncSemaphore.Benchmark/Baseline/BaselineReleaser.cs
+++ b/AsyncSemaphore.Benchmark/Baseline/BaselineReleaser.cs
@@ -1,0 +1,20 @@
+using System.Runtime.CompilerServices;
+
+namespace AsyncSemaphore.Benchmark.Baseline;
+
+public struct BaselineReleaser : IDisposable
+{
+    private BaselineAsyncSemaphore? _semaphore;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal BaselineReleaser(BaselineAsyncSemaphore semaphore)
+    {
+        _semaphore = semaphore;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref _semaphore, null)?.Release();
+    }
+}

--- a/AsyncSemaphore.Benchmark/Benchmarks.cs
+++ b/AsyncSemaphore.Benchmark/Benchmarks.cs
@@ -12,8 +12,11 @@ public class Benchmarks
     private const int ParallelWorkers = 4;
     private const int ParallelOperationsPerWorker = 250;
 
+    private static readonly TimeSpan LongTimeout = TimeSpan.FromMinutes(5);
+
     private readonly SemaphoreSlim _semaphoreSlim = new(1, 1);
     private readonly Semaphores.AsyncSemaphore _asyncSemaphore = new(1);
+    private readonly CancellationTokenSource _cts = new();
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Uncontended")]
@@ -61,6 +64,112 @@ public class Benchmarks
         for (var i = 0; i < HandoffOperations; i++)
         {
             var pending = _asyncSemaphore.WaitAsync();
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("TimeoutUncontended")]
+    public async Task SemaphoreSlim_Timeout()
+    {
+        try
+        {
+            await _semaphoreSlim.WaitAsync(LongTimeout);
+        }
+        finally
+        {
+            _semaphoreSlim.Release();
+        }
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("TimeoutUncontended")]
+    public async Task AsyncSemaphore_Timeout()
+    {
+        using var _ = await _asyncSemaphore.WaitAsync(LongTimeout);
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("TokenUncontended")]
+    public async Task SemaphoreSlim_Token()
+    {
+        try
+        {
+            await _semaphoreSlim.WaitAsync(_cts.Token);
+        }
+        finally
+        {
+            _semaphoreSlim.Release();
+        }
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("TokenUncontended")]
+    public async Task AsyncSemaphore_Token()
+    {
+        using var _ = await _asyncSemaphore.WaitAsync(_cts.Token);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("TimeoutHandoff")]
+    public async Task SemaphoreSlim_TimeoutHandoff()
+    {
+        await _semaphoreSlim.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _semaphoreSlim.WaitAsync(LongTimeout);
+            _semaphoreSlim.Release();
+            await pending;
+        }
+
+        _semaphoreSlim.Release();
+    }
+
+    [Benchmark(OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("TimeoutHandoff")]
+    public async Task AsyncSemaphore_TimeoutHandoff()
+    {
+        var holder = await _asyncSemaphore.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _asyncSemaphore.WaitAsync(LongTimeout);
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("TokenHandoff")]
+    public async Task SemaphoreSlim_TokenHandoff()
+    {
+        await _semaphoreSlim.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _semaphoreSlim.WaitAsync(_cts.Token);
+            _semaphoreSlim.Release();
+            await pending;
+        }
+
+        _semaphoreSlim.Release();
+    }
+
+    [Benchmark(OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("TokenHandoff")]
+    public async Task AsyncSemaphore_TokenHandoff()
+    {
+        var holder = await _asyncSemaphore.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _asyncSemaphore.WaitAsync(_cts.Token);
             holder.Dispose();
             holder = await pending;
         }

--- a/AsyncSemaphore.Benchmark/Benchmarks.cs
+++ b/AsyncSemaphore.Benchmark/Benchmarks.cs
@@ -1,16 +1,23 @@
-﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 
 namespace AsyncSemaphore.Benchmark;
 
 [MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
 public class Benchmarks
 {
+    private const int HandoffOperations = 1_000;
+    private const int ParallelWorkers = 4;
+    private const int ParallelOperationsPerWorker = 250;
+
     private readonly SemaphoreSlim _semaphoreSlim = new(1, 1);
     private readonly Semaphores.AsyncSemaphore _asyncSemaphore = new(1);
 
-    [Benchmark]
-    public async Task Raw_Semaphore_Slim()
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Uncontended")]
+    public async Task SemaphoreSlim()
     {
         try
         {
@@ -21,18 +28,79 @@ public class Benchmarks
             _semaphoreSlim.Release();
         }
     }
-    
+
     [Benchmark]
-    public async Task AsyncSemaphore_With_Inherited_Scope()
+    [BenchmarkCategory("Uncontended")]
+    public async Task AsyncSemaphore()
     {
         using var _ = await _asyncSemaphore.WaitAsync();
     }
-    
-    [Benchmark]
-    public async Task AsyncSemaphore_With_Braced_Scope()
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("AsyncHandoff")]
+    public async Task SemaphoreSlim_AsyncHandoff()
     {
-        using (await _asyncSemaphore.WaitAsync())
+        await _semaphoreSlim.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
         {
+            var pending = _semaphoreSlim.WaitAsync();
+            _semaphoreSlim.Release();
+            await pending;
         }
+
+        _semaphoreSlim.Release();
+    }
+
+    [Benchmark(OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("AsyncHandoff")]
+    public async Task AsyncSemaphore_AsyncHandoff()
+    {
+        var holder = await _asyncSemaphore.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _asyncSemaphore.WaitAsync();
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = ParallelWorkers * ParallelOperationsPerWorker)]
+    [BenchmarkCategory("Parallel")]
+    public Task SemaphoreSlim_Parallel()
+    {
+        return Task.WhenAll(Enumerable.Range(0, ParallelWorkers).Select(async _ =>
+        {
+            for (var i = 0; i < ParallelOperationsPerWorker; i++)
+            {
+                await _semaphoreSlim.WaitAsync();
+
+                try
+                {
+                    await Task.Yield();
+                }
+                finally
+                {
+                    _semaphoreSlim.Release();
+                }
+            }
+        }));
+    }
+
+    [Benchmark(OperationsPerInvoke = ParallelWorkers * ParallelOperationsPerWorker)]
+    [BenchmarkCategory("Parallel")]
+    public Task AsyncSemaphore_Parallel()
+    {
+        return Task.WhenAll(Enumerable.Range(0, ParallelWorkers).Select(async _ =>
+        {
+            for (var i = 0; i < ParallelOperationsPerWorker; i++)
+            {
+                using var @lock = await _asyncSemaphore.WaitAsync();
+                await Task.Yield();
+            }
+        }));
     }
 }

--- a/AsyncSemaphore.Benchmark/PoolComparisonBenchmarks.cs
+++ b/AsyncSemaphore.Benchmark/PoolComparisonBenchmarks.cs
@@ -1,0 +1,174 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Reservoir;
+
+namespace AsyncSemaphore.Benchmark;
+
+/// <summary>
+/// Compares the hand-rolled three-tier waiter pool used inside AsyncSemaphore
+/// (thread-static slot -> instance slot -> ConcurrentQueue) against the Reservoir
+/// object pool, both in isolation and integrated into the async handoff path.
+/// </summary>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class PoolComparisonBenchmarks
+{
+    private const int HandoffOperations = 1_000;
+    private const int ParallelWorkers = 4;
+    private const int ParallelOperationsPerWorker = 250;
+
+    private readonly CustomThreeTierPool _customPool = new();
+    private readonly ObjectPool<Node, NodePolicy> _reservoirPool = new(default, 128, threadLocalFastPath: true);
+
+    private readonly Semaphores.AsyncSemaphore _asyncSemaphore = new(1);
+    private readonly ReservoirPooledAsyncSemaphore _reservoirSemaphore = new(1);
+
+    public sealed class Node
+    {
+        public object? Owner;
+        public int Value;
+    }
+
+    private struct NodePolicy : IPooledObjectPolicy<Node>
+    {
+        public Node Create() => new();
+
+        public bool TryReset(Node obj) => true;
+
+        public void Destroy(Node obj)
+        {
+        }
+    }
+
+    /// <summary>Mirror of the pool tiers inside AsyncSemaphore, extracted for isolation.</summary>
+    private sealed class CustomThreeTierPool
+    {
+        [ThreadStatic]
+        private static Node? t_cached;
+
+        private readonly ConcurrentQueue<Node> _queue = new();
+        private Node? _slot;
+
+        public Node Rent()
+        {
+            var node = t_cached;
+
+            if (node is not null)
+            {
+                t_cached = null;
+            }
+            else if ((node = Interlocked.Exchange(ref _slot, null)) is null && !_queue.TryDequeue(out node))
+            {
+                node = new Node();
+            }
+
+            node.Owner = this;
+
+            return node;
+        }
+
+        public void Return(Node node)
+        {
+            if (t_cached is null)
+            {
+                node.Owner = null;
+                t_cached = node;
+
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref _slot, node, null) != null)
+            {
+                _queue.Enqueue(node);
+            }
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("PoolMicro")]
+    public int CustomPool_RentReturn()
+    {
+        var node = _customPool.Rent();
+        node.Value++;
+        var value = node.Value;
+        _customPool.Return(node);
+
+        return value;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("PoolMicro")]
+    public int Reservoir_RentReturn()
+    {
+        var node = _reservoirPool.Rent();
+        node.Value++;
+        var value = node.Value;
+        _reservoirPool.Return(node);
+
+        return value;
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = ParallelWorkers * ParallelOperationsPerWorker)]
+    [BenchmarkCategory("PoolMicroParallel")]
+    public Task CustomPool_RentReturn_Parallel()
+    {
+        return Task.WhenAll(Enumerable.Range(0, ParallelWorkers).Select(_ => Task.Run(() =>
+        {
+            for (var i = 0; i < ParallelOperationsPerWorker; i++)
+            {
+                var node = _customPool.Rent();
+                node.Value++;
+                _customPool.Return(node);
+            }
+        })));
+    }
+
+    [Benchmark(OperationsPerInvoke = ParallelWorkers * ParallelOperationsPerWorker)]
+    [BenchmarkCategory("PoolMicroParallel")]
+    public Task Reservoir_RentReturn_Parallel()
+    {
+        return Task.WhenAll(Enumerable.Range(0, ParallelWorkers).Select(_ => Task.Run(() =>
+        {
+            for (var i = 0; i < ParallelOperationsPerWorker; i++)
+            {
+                var node = _reservoirPool.Rent();
+                node.Value++;
+                _reservoirPool.Return(node);
+            }
+        })));
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("PooledHandoff")]
+    public async Task CurrentPool_AsyncHandoff()
+    {
+        var holder = await _asyncSemaphore.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _asyncSemaphore.WaitAsync();
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+
+    [Benchmark(OperationsPerInvoke = HandoffOperations)]
+    [BenchmarkCategory("PooledHandoff")]
+    public async Task ReservoirPool_AsyncHandoff()
+    {
+        var holder = await _reservoirSemaphore.WaitAsync();
+
+        for (var i = 0; i < HandoffOperations; i++)
+        {
+            var pending = _reservoirSemaphore.WaitAsync();
+            holder.Dispose();
+            holder = await pending;
+        }
+
+        holder.Dispose();
+    }
+}

--- a/AsyncSemaphore.Benchmark/PoolComparisonBenchmarks.cs
+++ b/AsyncSemaphore.Benchmark/PoolComparisonBenchmarks.cs
@@ -27,7 +27,6 @@ public class PoolComparisonBenchmarks
 
     public sealed class Node
     {
-        public object? Owner;
         public int Value;
     }
 
@@ -64,8 +63,6 @@ public class PoolComparisonBenchmarks
                 node = new Node();
             }
 
-            node.Owner = this;
-
             return node;
         }
 
@@ -73,7 +70,6 @@ public class PoolComparisonBenchmarks
         {
             if (t_cached is null)
             {
-                node.Owner = null;
                 t_cached = node;
 
                 return;

--- a/AsyncSemaphore.Benchmark/Program.cs
+++ b/AsyncSemaphore.Benchmark/Program.cs
@@ -1,4 +1,4 @@
 using AsyncSemaphore.Benchmark;
 using BenchmarkDotNet.Running;
 
-BenchmarkSwitcher.FromTypes([typeof(Benchmarks), typeof(PoolComparisonBenchmarks)]).Run(args);
+BenchmarkSwitcher.FromTypes([typeof(Benchmarks), typeof(PoolComparisonBenchmarks), typeof(AbBenchmarks)]).Run(args);

--- a/AsyncSemaphore.Benchmark/Program.cs
+++ b/AsyncSemaphore.Benchmark/Program.cs
@@ -1,4 +1,4 @@
-﻿using AsyncSemaphore.Benchmark;
+using AsyncSemaphore.Benchmark;
 using BenchmarkDotNet.Running;
 
-var summary = BenchmarkRunner.Run<Benchmarks>();
+BenchmarkSwitcher.FromTypes([typeof(Benchmarks), typeof(PoolComparisonBenchmarks)]).Run(args);

--- a/AsyncSemaphore.Benchmark/ReservoirPooledAsyncSemaphore.cs
+++ b/AsyncSemaphore.Benchmark/ReservoirPooledAsyncSemaphore.cs
@@ -1,0 +1,196 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks.Sources;
+using Reservoir;
+
+namespace AsyncSemaphore.Benchmark;
+
+/// <summary>
+/// Benchmark-only copy of <see cref="Semaphores.AsyncSemaphore"/> with the hand-rolled
+/// three-tier waiter pool replaced by a Reservoir <see cref="ObjectPool{T, TPolicy}"/>
+/// (struct policy, thread-local fast path enabled). Everything else is identical so the
+/// handoff benchmark isolates the pooling strategy.
+/// </summary>
+public sealed class ReservoirPooledAsyncSemaphore
+{
+    private int _count;
+
+    private readonly ConcurrentQueue<Waiter> _waiters = new();
+    private readonly ObjectPool<Waiter, WaiterPolicy> _nodePool = new(default, 128, threadLocalFastPath: true);
+
+    public ReservoirPooledAsyncSemaphore(int maxCount)
+    {
+        _count = maxCount;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask<Releaser> WaitAsync()
+    {
+        if (TryAcquireFast())
+        {
+            return new ValueTask<Releaser>(new Releaser(this));
+        }
+
+        return EnqueueWaiter();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryAcquireFast()
+    {
+        var count = Volatile.Read(ref _count);
+
+        while (count > 0)
+        {
+            var observed = Interlocked.CompareExchange(ref _count, count - 1, count);
+
+            if (observed == count)
+            {
+                return true;
+            }
+
+            count = observed;
+        }
+
+        return false;
+    }
+
+    internal void Release()
+    {
+        if (Interlocked.Increment(ref _count) <= 0)
+        {
+            ReleaseNextWaiter();
+        }
+    }
+
+    private void ReleaseNextWaiter()
+    {
+        while (true)
+        {
+            Waiter? waiter;
+            var spinner = default(SpinWait);
+
+            while (!_waiters.TryDequeue(out waiter))
+            {
+                spinner.SpinOnce();
+            }
+
+            if (waiter.TryClaim())
+            {
+                waiter.SetAcquired();
+                return;
+            }
+
+            if (Interlocked.Increment(ref _count) > 0)
+            {
+                return;
+            }
+        }
+    }
+
+    private ValueTask<Releaser> EnqueueWaiter()
+    {
+        var waiter = _nodePool.Rent();
+
+        waiter.SetOwner(this);
+
+        var version = waiter.Version;
+
+        if (Interlocked.Decrement(ref _count) >= 0)
+        {
+            ReturnWaiter(waiter);
+
+            return new ValueTask<Releaser>(new Releaser(this));
+        }
+
+        _waiters.Enqueue(waiter);
+
+        return new ValueTask<Releaser>(waiter, version);
+    }
+
+    private void ReturnWaiter(Waiter waiter)
+    {
+        _nodePool.Return(waiter);
+    }
+
+    public struct Releaser : IDisposable
+    {
+        private ReservoirPooledAsyncSemaphore? _semaphore;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal Releaser(ReservoirPooledAsyncSemaphore semaphore)
+        {
+            _semaphore = semaphore;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _semaphore, null)?.Release();
+        }
+    }
+
+    internal struct WaiterPolicy : IPooledObjectPolicy<Waiter>
+    {
+        public Waiter Create() => new();
+
+        public bool TryReset(Waiter obj) => true;
+
+        public void Destroy(Waiter obj)
+        {
+        }
+    }
+
+    internal sealed class Waiter : IValueTaskSource<Releaser>
+    {
+        private ReservoirPooledAsyncSemaphore _owner = null!;
+
+        private ManualResetValueTaskSourceCore<Releaser> _core;
+
+        public Waiter()
+        {
+            _core.RunContinuationsAsynchronously = true;
+        }
+
+        public short Version
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _core.Version;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetOwner(ReservoirPooledAsyncSemaphore owner)
+        {
+            _owner = owner;
+        }
+
+        // The benchmark only exercises non-cancellable waits, matching the production
+        // fast path where TryClaim short-circuits without an interlocked operation.
+        public bool TryClaim() => true;
+
+        public void SetAcquired()
+        {
+            _core.SetResult(new Releaser(_owner));
+        }
+
+        public Releaser GetResult(short token)
+        {
+            var result = _core.GetResult(token);
+
+            _core.Reset();
+
+            _owner.ReturnWaiter(this);
+
+            return result;
+        }
+
+        public ValueTaskSourceStatus GetStatus(short token)
+        {
+            return _core.GetStatus(token);
+        }
+
+        public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        {
+            _core.OnCompleted(continuation, state, token, flags);
+        }
+    }
+}

--- a/AsyncSemaphore.UnitTests/ContentionTests.cs
+++ b/AsyncSemaphore.UnitTests/ContentionTests.cs
@@ -2,6 +2,8 @@
 // semaphore's internals, which is exactly what the usage analyzers guard against.
 #pragma warning disable SEM0001, SEM0002, SEM0003
 
+using TUnit.Assertions.Enums;
+
 namespace AsyncSemaphore.UnitTests;
 
 /// <summary>
@@ -32,7 +34,7 @@ public class ContentionTests
 
         await WhenAllWithTimeout(waiters);
 
-        await Assert.That(completionOrder).IsEquivalentTo(Enumerable.Range(0, 10).ToList());
+        await Assert.That(completionOrder).IsEquivalentTo(Enumerable.Range(0, 10).ToList(), CollectionOrdering.Matching);
         await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
 
         async Task Consume(ValueTask<Semaphores.AsyncSemaphoreReleaser> pending, int index)
@@ -93,7 +95,7 @@ public class ContentionTests
         const int workers = 12;
         const int iterationsPerWorker = 2_000;
 
-        var tasks = Enumerable.Range(0, workers).Select(async workerIndex =>
+        var tasks = Enumerable.Range(0, workers).Select(workerIndex => Task.Run(async () =>
         {
             for (var i = 0; i < iterationsPerWorker; i++)
             {
@@ -111,7 +113,7 @@ public class ContentionTests
                 Interlocked.Decrement(ref holders);
                 Interlocked.Increment(ref completed);
             }
-        }).ToArray();
+        })).ToArray();
 
         await WhenAllWithTimeout(tasks);
 
@@ -135,25 +137,39 @@ public class ContentionTests
 
         using var neverCancelled = new CancellationTokenSource();
 
+        // Hold every permit so each worker's first wait of every flavor is guaranteed to queue
+        var initialHolders = await HoldAllPermits(semaphore, maxCount);
+        var allQueued = new QueuedGate(workers);
+
         // Each flavor takes a different slow path: non-cancellable (skips the claim CAS),
         // token-armed (claim CAS + registration), and timer-armed (claim CAS + timer)
-        var tasks = Enumerable.Range(0, workers).Select(async workerIndex =>
+        var tasks = Enumerable.Range(0, workers).Select(workerIndex => Task.Run(async () =>
         {
             for (var i = 0; i < iterationsPerWorker; i++)
             {
-                using var @lock = (workerIndex % 3) switch
+                var pending = (workerIndex % 3) switch
                 {
-                    0 => await semaphore.WaitAsync(),
-                    1 => await semaphore.WaitAsync(neverCancelled.Token),
-                    _ => await semaphore.WaitAsync(TimeSpan.FromMinutes(5)),
+                    0 => semaphore.WaitAsync(),
+                    1 => semaphore.WaitAsync(neverCancelled.Token),
+                    _ => semaphore.WaitAsync(TimeSpan.FromMinutes(5)),
                 };
+
+                if (i == 0)
+                {
+                    allQueued.Signal();
+                }
+
+                using var @lock = await pending;
 
                 var current = Interlocked.Increment(ref holders);
                 InterlockedMax(ref maxObserved, current);
                 Interlocked.Decrement(ref holders);
                 Interlocked.Increment(ref completed);
             }
-        }).ToArray();
+        })).ToArray();
+
+        await allQueued.AllQueued;
+        ReleaseAll(initialHolders);
 
         await WhenAllWithTimeout(tasks);
 
@@ -427,7 +443,8 @@ public class ContentionTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.That(async () => await semaphore.WaitAsync(cts.Token))
+        // A synchronous delegate: the throw must happen before any ValueTask is handed back
+        await Assert.That(() => { _ = semaphore.WaitAsync(cts.Token); })
             .ThrowsExactly<OperationCanceledException>();
 
         await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
@@ -505,22 +522,34 @@ public class ContentionTests
         const int workers = 8;
         const int iterationsPerWorker = 3_000;
 
-        var tasks = Enumerable.Range(0, workers).Select(async workerIndex =>
+        // Hold both permits so every worker's first wait queues on A or B, then release
+        // both at once so the two instances see overlapping waits from the same threads
+        var holderA = await HoldAllPermits(semaphoreA, 1);
+        var holderB = await HoldAllPermits(semaphoreB, 1);
+        var allQueued = new QueuedGate(workers);
+
+        var tasks = Enumerable.Range(0, workers).Select(workerIndex => Task.Run(async () =>
         {
             for (var i = 0; i < iterationsPerWorker; i++)
             {
-                if ((workerIndex + i) % 2 == 0)
-                {
-                    using var @lock = await semaphoreA.WaitAsync();
+                var useA = (workerIndex + i) % 2 == 0;
+                var pending = useA ? semaphoreA.WaitAsync() : semaphoreB.WaitAsync();
 
+                if (i == 0)
+                {
+                    allQueued.Signal();
+                }
+
+                using var @lock = await pending;
+
+                if (useA)
+                {
                     var current = Interlocked.Increment(ref inA);
                     InterlockedMax(ref maxA, current);
                     Interlocked.Decrement(ref inA);
                 }
                 else
                 {
-                    using var @lock = await semaphoreB.WaitAsync();
-
                     var current = Interlocked.Increment(ref inB);
                     InterlockedMax(ref maxB, current);
                     Interlocked.Decrement(ref inB);
@@ -528,7 +557,11 @@ public class ContentionTests
 
                 Interlocked.Increment(ref completed);
             }
-        }).ToArray();
+        })).ToArray();
+
+        await allQueued.AllQueued;
+        ReleaseAll(holderA);
+        ReleaseAll(holderB);
 
         await WhenAllWithTimeout(tasks);
 
@@ -552,11 +585,24 @@ public class ContentionTests
         const int workers = 6;
         const int iterationsPerWorker = 2_000;
 
-        var tasks = Enumerable.Range(0, workers).Select(async _ =>
+        // Hold every outer and inner permit so all workers queue on the outer semaphore, then
+        // release everything at once so the winners immediately contend on the inner one
+        var outerHolders = await HoldAllPermits(outer, 2);
+        var innerHolders = await HoldAllPermits(inner, 1);
+        var allQueued = new QueuedGate(workers);
+
+        var tasks = Enumerable.Range(0, workers).Select(_ => Task.Run(async () =>
         {
             for (var i = 0; i < iterationsPerWorker; i++)
             {
-                using var outerLock = await outer.WaitAsync();
+                var pendingOuter = outer.WaitAsync();
+
+                if (i == 0)
+                {
+                    allQueued.Signal();
+                }
+
+                using var outerLock = await pendingOuter;
                 using var innerLock = await inner.WaitAsync();
 
                 var current = Interlocked.Increment(ref inInner);
@@ -564,7 +610,11 @@ public class ContentionTests
                 Interlocked.Decrement(ref inInner);
                 Interlocked.Increment(ref completed);
             }
-        }).ToArray();
+        })).ToArray();
+
+        await allQueued.AllQueued;
+        ReleaseAll(outerHolders);
+        ReleaseAll(innerHolders);
 
         await WhenAllWithTimeout(tasks);
 
@@ -626,6 +676,28 @@ public class ContentionTests
 
     public static IEnumerable<int> PermitCounts() => [1, 2, 4, 8];
 
+    private static async Task<Semaphores.AsyncSemaphoreReleaser[]> HoldAllPermits(Semaphores.AsyncSemaphore semaphore, int maxCount)
+    {
+        var holders = new Semaphores.AsyncSemaphoreReleaser[maxCount];
+
+        for (var i = 0; i < maxCount; i++)
+        {
+            holders[i] = await semaphore.WaitAsync();
+        }
+
+        return holders;
+    }
+
+    private static void ReleaseAll(Semaphores.AsyncSemaphoreReleaser[] holders)
+    {
+#pragma warning disable SEM0004 // the releasers were deliberately kept out of a using so the test controls the release moment
+        for (var i = 0; i < holders.Length; i++)
+        {
+            holders[i].Dispose();
+        }
+#pragma warning restore SEM0004
+    }
+
     private static void InterlockedMax(ref int location, int value)
     {
         int current;
@@ -647,5 +719,30 @@ public class ContentionTests
         }
 
         await all;
+    }
+
+    /// <summary>
+    /// Completes once every worker has issued its first wait. Combined with pre-held permits this
+    /// guarantees each worker actually queues instead of racing through the fast path unopposed.
+    /// </summary>
+    private sealed class QueuedGate
+    {
+        private readonly TaskCompletionSource<bool> _allQueued = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _remaining;
+
+        public QueuedGate(int workers)
+        {
+            _remaining = workers;
+        }
+
+        public Task AllQueued => _allQueued.Task;
+
+        public void Signal()
+        {
+            if (Interlocked.Decrement(ref _remaining) == 0)
+            {
+                _allQueued.TrySetResult(true);
+            }
+        }
     }
 }

--- a/AsyncSemaphore.UnitTests/ContentionTests.cs
+++ b/AsyncSemaphore.UnitTests/ContentionTests.cs
@@ -1,0 +1,651 @@
+// These tests deliberately defer awaits and split acquire from release to race the
+// semaphore's internals, which is exactly what the usage analyzers guard against.
+#pragma warning disable SEM0001, SEM0002, SEM0003
+
+namespace AsyncSemaphore.UnitTests;
+
+/// <summary>
+/// Stress tests targeting the lock-free core: the fast-path CAS, the decrement-to-enqueue
+/// commit window, the claim/cancel CAS, dead-node settlement, and the waiter node pools.
+/// </summary>
+public class ContentionTests
+{
+    private static readonly TimeSpan StressTimeout = TimeSpan.FromSeconds(60);
+
+    [Test]
+    public async Task Queued_Waiters_Are_Released_In_Fifo_Order()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        var holder = await semaphore.WaitAsync();
+
+        var completionOrder = new List<int>();
+        var waiters = new List<Task>();
+
+        // WaitAsync enqueues synchronously before returning, so call order == queue order
+        for (var i = 0; i < 10; i++)
+        {
+            waiters.Add(Consume(semaphore.WaitAsync(), i));
+        }
+
+        await Task.Run(holder.Dispose);
+
+        await WhenAllWithTimeout(waiters);
+
+        await Assert.That(completionOrder).IsEquivalentTo(Enumerable.Range(0, 10).ToList());
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        async Task Consume(ValueTask<Semaphores.AsyncSemaphoreReleaser> pending, int index)
+        {
+            using var @lock = await pending;
+
+            lock (completionOrder)
+            {
+                completionOrder.Add(index);
+            }
+        }
+    }
+
+    [Test]
+    public async Task Sync_Hot_Loop_Never_Violates_Mutual_Exclusion()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        var inCriticalSection = 0;
+        var maxObserved = 0;
+        long sharedCounter = 0;
+
+        const int workers = 8;
+        const int iterationsPerWorker = 20_000;
+
+        // No awaits inside the critical section: hammers the fast-path CAS and the
+        // synchronous release/handoff transitions as hard as possible
+        var tasks = Enumerable.Range(0, workers).Select(_ => Task.Run(async () =>
+        {
+            for (var i = 0; i < iterationsPerWorker; i++)
+            {
+                using var @lock = await semaphore.WaitAsync();
+
+                var current = Interlocked.Increment(ref inCriticalSection);
+                InterlockedMax(ref maxObserved, current);
+                sharedCounter++; // unsynchronized on purpose; semaphore is the only guard
+                Interlocked.Decrement(ref inCriticalSection);
+            }
+        })).ToArray();
+
+        await WhenAllWithTimeout(tasks);
+
+        await Assert.That(maxObserved).IsEqualTo(1);
+        await Assert.That(sharedCounter).IsEqualTo((long)workers * iterationsPerWorker);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [MethodDataSource(nameof(PermitCounts))]
+    public async Task Permit_Limit_Holds_For_All_Max_Counts(int maxCount)
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(maxCount);
+
+        var holders = 0;
+        var maxObserved = 0;
+        var completed = 0;
+
+        const int workers = 12;
+        const int iterationsPerWorker = 2_000;
+
+        var tasks = Enumerable.Range(0, workers).Select(async workerIndex =>
+        {
+            for (var i = 0; i < iterationsPerWorker; i++)
+            {
+                using var @lock = await semaphore.WaitAsync();
+
+                var current = Interlocked.Increment(ref holders);
+                InterlockedMax(ref maxObserved, current);
+
+                // Alternate sync and async holds so both completion paths are exercised
+                if ((workerIndex + i) % 2 == 0)
+                {
+                    await Task.Yield();
+                }
+
+                Interlocked.Decrement(ref holders);
+                Interlocked.Increment(ref completed);
+            }
+        }).ToArray();
+
+        await WhenAllWithTimeout(tasks);
+
+        await Assert.That(maxObserved).IsLessThanOrEqualTo(maxCount);
+        await Assert.That(completed).IsEqualTo(workers * iterationsPerWorker);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(maxCount);
+    }
+
+    [Test]
+    public async Task Mixed_Wait_Flavors_Contend_Without_Corruption()
+    {
+        const int maxCount = 3;
+        using var semaphore = new Semaphores.AsyncSemaphore(maxCount);
+
+        var holders = 0;
+        var maxObserved = 0;
+        var completed = 0;
+
+        const int workers = 9;
+        const int iterationsPerWorker = 2_000;
+
+        using var neverCancelled = new CancellationTokenSource();
+
+        // Each flavor takes a different slow path: non-cancellable (skips the claim CAS),
+        // token-armed (claim CAS + registration), and timer-armed (claim CAS + timer)
+        var tasks = Enumerable.Range(0, workers).Select(async workerIndex =>
+        {
+            for (var i = 0; i < iterationsPerWorker; i++)
+            {
+                using var @lock = (workerIndex % 3) switch
+                {
+                    0 => await semaphore.WaitAsync(),
+                    1 => await semaphore.WaitAsync(neverCancelled.Token),
+                    _ => await semaphore.WaitAsync(TimeSpan.FromMinutes(5)),
+                };
+
+                var current = Interlocked.Increment(ref holders);
+                InterlockedMax(ref maxObserved, current);
+                Interlocked.Decrement(ref holders);
+                Interlocked.Increment(ref completed);
+            }
+        }).ToArray();
+
+        await WhenAllWithTimeout(tasks);
+
+        await Assert.That(maxObserved).IsLessThanOrEqualTo(maxCount);
+        await Assert.That(completed).IsEqualTo(workers * iterationsPerWorker);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(maxCount);
+    }
+
+    [Test]
+    public async Task Random_Cancellation_Under_Contention_Accounts_For_Every_Wait()
+    {
+        const int maxCount = 2;
+        using var semaphore = new Semaphores.AsyncSemaphore(maxCount);
+
+        var acquired = 0;
+        var cancelled = 0;
+        var holders = 0;
+        var maxObserved = 0;
+
+        const int workers = 8;
+        const int iterationsPerWorker = 1_000;
+
+        var tasks = Enumerable.Range(0, workers).Select(workerIndex => Task.Run(async () =>
+        {
+            var random = new Random(workerIndex * 7919);
+
+            for (var i = 0; i < iterationsPerWorker; i++)
+            {
+                using var cts = new CancellationTokenSource();
+
+                var pending = semaphore.WaitAsync(cts.Token);
+
+                // Cancel concurrently on some iterations so the claim/cancel CAS races both ways
+                var cancelTask = random.Next(3) == 0 ? Task.Run(cts.Cancel) : Task.CompletedTask;
+
+                try
+                {
+                    using (await pending)
+                    {
+                        var current = Interlocked.Increment(ref holders);
+                        InterlockedMax(ref maxObserved, current);
+                        Interlocked.Decrement(ref holders);
+                        Interlocked.Increment(ref acquired);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    Interlocked.Increment(ref cancelled);
+                }
+
+                await cancelTask;
+            }
+        })).ToArray();
+
+        await WhenAllWithTimeout(tasks);
+
+        // Every wait resolved exactly one way, and no permit was lost or duplicated
+        await Assert.That(acquired + cancelled).IsEqualTo(workers * iterationsPerWorker);
+        await Assert.That(maxObserved).IsLessThanOrEqualTo(maxCount);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(maxCount);
+
+        using var final = await semaphore.WaitAsync();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(maxCount - 1);
+    }
+
+    [Test]
+    public async Task Timeout_Storm_Under_Contention_Accounts_For_Every_Wait()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        var acquired = 0;
+        var timedOut = 0;
+
+        const int workers = 8;
+        const int iterationsPerWorker = 300;
+
+        var tasks = Enumerable.Range(0, workers).Select(workerIndex => Task.Run(async () =>
+        {
+            var random = new Random(workerIndex * 104729);
+
+            for (var i = 0; i < iterationsPerWorker; i++)
+            {
+                try
+                {
+                    using (await semaphore.WaitAsync(TimeSpan.FromMilliseconds(random.Next(0, 20))))
+                    {
+                        Interlocked.Increment(ref acquired);
+
+                        if (random.Next(2) == 0)
+                        {
+                            await Task.Yield();
+                        }
+                    }
+                }
+                catch (TimeoutException)
+                {
+                    Interlocked.Increment(ref timedOut);
+                }
+            }
+        })).ToArray();
+
+        await WhenAllWithTimeout(tasks);
+
+        await Assert.That(acquired + timedOut).IsEqualTo(workers * iterationsPerWorker);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        using var final = await semaphore.WaitAsync();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Mass_Waiter_Queue_Drains_Completely_From_Single_Release()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        var holder = await semaphore.WaitAsync();
+
+        var completed = 0;
+        const int waiters = 1_000;
+        const int spawners = 8;
+
+        // Enqueue from many threads at once so waiters land in the queue while
+        // release handoffs are already chaining through it
+        var spawnerTasks = Enumerable.Range(0, spawners).Select(_ => Task.Run(async () =>
+        {
+            var localWaiters = new Task[waiters / spawners];
+
+            for (var i = 0; i < localWaiters.Length; i++)
+            {
+                localWaiters[i] = Consume();
+            }
+
+            await Task.WhenAll(localWaiters);
+        })).ToArray();
+
+        await Task.Run(holder.Dispose);
+
+        await WhenAllWithTimeout(spawnerTasks);
+
+        await Assert.That(completed).IsEqualTo(waiters);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        async Task Consume()
+        {
+            using var @lock = await semaphore.WaitAsync();
+
+            Interlocked.Increment(ref completed);
+        }
+    }
+
+    [Test]
+    public async Task Cancelled_Waiters_Interleaved_With_Live_Waiters_Do_Not_Steal_Or_Block()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        var holder = await semaphore.WaitAsync();
+
+        using var cts = new CancellationTokenSource();
+
+        // Interleave live and doomed waiters in the queue: L D L D L D
+        var liveWaiters = new List<Task>();
+        var doomedWaiters = new List<Task>();
+        var liveCompleted = 0;
+
+        for (var i = 0; i < 3; i++)
+        {
+            liveWaiters.Add(ConsumeLive(semaphore.WaitAsync()));
+            doomedWaiters.Add(ConsumeDoomed(semaphore.WaitAsync(cts.Token)));
+        }
+
+        cts.Cancel();
+        await WhenAllWithTimeout(doomedWaiters);
+
+        // The dead nodes are still queued; releasing must settle them and still reach every live waiter
+        await Task.Run(holder.Dispose);
+
+        await WhenAllWithTimeout(liveWaiters);
+
+        await Assert.That(liveCompleted).IsEqualTo(3);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        async Task ConsumeLive(ValueTask<Semaphores.AsyncSemaphoreReleaser> pending)
+        {
+            using var @lock = await pending;
+
+            Interlocked.Increment(ref liveCompleted);
+        }
+
+        async Task ConsumeDoomed(ValueTask<Semaphores.AsyncSemaphoreReleaser> pending)
+        {
+            try
+            {
+                using var @lock = await pending;
+            }
+            catch (OperationCanceledException)
+            {
+                // expected
+            }
+        }
+    }
+
+    [Test]
+    public async Task Cancellation_After_Acquisition_Is_A_NoOp()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        using var cts = new CancellationTokenSource();
+
+        var holder = await semaphore.WaitAsync();
+
+        // Force the slow path so the token is actually registered
+        var pending = semaphore.WaitAsync(cts.Token);
+
+        await Task.Run(holder.Dispose);
+
+        using (await pending)
+        {
+            // The waiter has been claimed; the cancellation callback must lose the CAS
+            cts.Cancel();
+
+            await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+        }
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        using var final = await semaphore.WaitAsync();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Timeout_Firing_After_Acquisition_Is_A_NoOp()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        var holder = await semaphore.WaitAsync();
+
+        // Force the slow path so the timer is actually armed
+        var pending = semaphore.WaitAsync(TimeSpan.FromMilliseconds(200));
+
+        await Task.Run(holder.Dispose);
+
+        using (await pending)
+        {
+            // Hold past the original timeout; the timer callback must lose the CAS
+            await Task.Delay(400);
+
+            await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+        }
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Zero_Timeout_Acquires_When_Permit_Available()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        using (await semaphore.WaitAsync(TimeSpan.Zero))
+        {
+            await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+        }
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task PreCancelled_Token_Throws_Synchronously_Without_Touching_The_Count()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.That(async () => await semaphore.WaitAsync(cts.Token))
+            .ThrowsExactly<OperationCanceledException>();
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        using var @lock = await semaphore.WaitAsync();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Double_Dispose_Of_Releaser_Releases_Exactly_Once()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        var releaser = await semaphore.WaitAsync();
+
+#pragma warning disable SEM0004 // deliberately violating the analyzer to prove single-release semantics
+        releaser.Dispose();
+        releaser.Dispose();
+#pragma warning restore SEM0004
+
+        // A double release would have pushed the count past maxCount
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        // And must not have fabricated a permit for a waiter
+        using (await semaphore.WaitAsync())
+        {
+            await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+
+            await Assert.That(async () => await semaphore.WaitAsync(TimeSpan.FromMilliseconds(50)))
+                .ThrowsExactly<TimeoutException>();
+        }
+    }
+
+    [Test]
+    public async Task Release_From_A_Different_Thread_Hands_Off_Correctly()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        const int iterations = 2_000;
+
+        for (var i = 0; i < iterations; i++)
+        {
+            var releaser = await semaphore.WaitAsync();
+
+            var pending = semaphore.WaitAsync();
+
+            // Dispose on a foreign thread while this thread awaits the handoff
+            var releaseTask = Task.Run(releaser.Dispose);
+
+            using (await pending)
+            {
+                await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+            }
+
+            await releaseTask;
+        }
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Two_Semaphores_On_Shared_Threads_Keep_Independent_Invariants()
+    {
+        // The thread-static waiter cache is shared across semaphores; nodes are re-owned
+        // on rent, so interleaving two instances on the same threads must not cross wires
+        using var semaphoreA = new Semaphores.AsyncSemaphore(1);
+        using var semaphoreB = new Semaphores.AsyncSemaphore(1);
+
+        var inA = 0;
+        var inB = 0;
+        var maxA = 0;
+        var maxB = 0;
+        var completed = 0;
+
+        const int workers = 8;
+        const int iterationsPerWorker = 3_000;
+
+        var tasks = Enumerable.Range(0, workers).Select(async workerIndex =>
+        {
+            for (var i = 0; i < iterationsPerWorker; i++)
+            {
+                if ((workerIndex + i) % 2 == 0)
+                {
+                    using var @lock = await semaphoreA.WaitAsync();
+
+                    var current = Interlocked.Increment(ref inA);
+                    InterlockedMax(ref maxA, current);
+                    Interlocked.Decrement(ref inA);
+                }
+                else
+                {
+                    using var @lock = await semaphoreB.WaitAsync();
+
+                    var current = Interlocked.Increment(ref inB);
+                    InterlockedMax(ref maxB, current);
+                    Interlocked.Decrement(ref inB);
+                }
+
+                Interlocked.Increment(ref completed);
+            }
+        }).ToArray();
+
+        await WhenAllWithTimeout(tasks);
+
+        await Assert.That(maxA).IsEqualTo(1);
+        await Assert.That(maxB).IsEqualTo(1);
+        await Assert.That(completed).IsEqualTo(workers * iterationsPerWorker);
+        await Assert.That(semaphoreA.CurrentCount).IsEqualTo(1);
+        await Assert.That(semaphoreB.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Nested_Semaphores_Under_Contention_Do_Not_Corrupt_Each_Other()
+    {
+        using var outer = new Semaphores.AsyncSemaphore(2);
+        using var inner = new Semaphores.AsyncSemaphore(1);
+
+        var inInner = 0;
+        var maxInner = 0;
+        var completed = 0;
+
+        const int workers = 6;
+        const int iterationsPerWorker = 2_000;
+
+        var tasks = Enumerable.Range(0, workers).Select(async _ =>
+        {
+            for (var i = 0; i < iterationsPerWorker; i++)
+            {
+                using var outerLock = await outer.WaitAsync();
+                using var innerLock = await inner.WaitAsync();
+
+                var current = Interlocked.Increment(ref inInner);
+                InterlockedMax(ref maxInner, current);
+                Interlocked.Decrement(ref inInner);
+                Interlocked.Increment(ref completed);
+            }
+        }).ToArray();
+
+        await WhenAllWithTimeout(tasks);
+
+        await Assert.That(maxInner).IsEqualTo(1);
+        await Assert.That(completed).IsEqualTo(workers * iterationsPerWorker);
+        await Assert.That(outer.CurrentCount).IsEqualTo(2);
+        await Assert.That(inner.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Cancel_Release_And_New_Waiters_All_Race_Without_Losing_Permits()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        const int iterations = 1_000;
+
+        for (var i = 0; i < iterations; i++)
+        {
+            var holder = await semaphore.WaitAsync();
+
+            using var cts = new CancellationTokenSource();
+
+            var doomed = semaphore.WaitAsync(cts.Token);
+            var live = semaphore.WaitAsync();
+
+            // Three-way race: release the permit, cancel the first waiter, and have a
+            // second live waiter queued behind the potentially-dead node
+            var releaseTask = Task.Run(holder.Dispose);
+            var cancelTask = Task.Run(cts.Cancel);
+
+            var doomedAcquired = false;
+
+            try
+            {
+                using (await doomed)
+                {
+                    doomedAcquired = true;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // cancellation won; the dead node must be settled without starving the live waiter
+            }
+
+            using (await live)
+            {
+            }
+
+            await Task.WhenAll(releaseTask, cancelTask);
+
+            _ = doomedAcquired;
+        }
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        using var final = await semaphore.WaitAsync();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+    }
+
+    public static IEnumerable<int> PermitCounts() => [1, 2, 4, 8];
+
+    private static void InterlockedMax(ref int location, int value)
+    {
+        int current;
+        do
+        {
+            current = Volatile.Read(ref location);
+        }
+        while (value > current && Interlocked.CompareExchange(ref location, value, current) != current);
+    }
+
+    private static async Task WhenAllWithTimeout(IEnumerable<Task> tasks)
+    {
+        var all = Task.WhenAll(tasks);
+        var completedFirst = await Task.WhenAny(all, Task.Delay(StressTimeout));
+
+        if (completedFirst != all)
+        {
+            throw new TimeoutException($"Stress test did not finish within {StressTimeout}; a waiter was likely lost.");
+        }
+
+        await all;
+    }
+}

--- a/AsyncSemaphore.UnitTests/Tests.cs
+++ b/AsyncSemaphore.UnitTests/Tests.cs
@@ -129,7 +129,9 @@ public class Tests
         const int workers = 8;
         const int iterationsPerWorker = 5_000;
 
-        var tasks = Enumerable.Range(0, workers).Select(async _ =>
+        // Task.Run puts every worker on its own thread; a plain async lambda with no await inside
+        // the loop would run each worker to completion inline and never actually contend
+        var tasks = Enumerable.Range(0, workers).Select(_ => Task.Run(async () =>
         {
             for (var i = 0; i < iterationsPerWorker; i++)
             {
@@ -140,7 +142,7 @@ public class Tests
                 Interlocked.Decrement(ref inCriticalSection);
                 Interlocked.Increment(ref completedIterations);
             }
-        }).ToArray();
+        })).ToArray();
 
         await Task.WhenAll(tasks);
 

--- a/AsyncSemaphore.UnitTests/Tests.cs
+++ b/AsyncSemaphore.UnitTests/Tests.cs
@@ -117,6 +117,194 @@ public class Tests
             .ThrowsExactly<OperationCanceledException>();
     }
 
+    [Test]
+    public async Task Mutual_Exclusion_Is_Never_Violated_Under_Contention()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        var inCriticalSection = 0;
+        var maxObserved = 0;
+        var completedIterations = 0;
+
+        const int workers = 8;
+        const int iterationsPerWorker = 5_000;
+
+        var tasks = Enumerable.Range(0, workers).Select(async _ =>
+        {
+            for (var i = 0; i < iterationsPerWorker; i++)
+            {
+                using var @lock = await semaphore.WaitAsync();
+
+                var current = Interlocked.Increment(ref inCriticalSection);
+                InterlockedMax(ref maxObserved, current);
+                Interlocked.Decrement(ref inCriticalSection);
+                Interlocked.Increment(ref completedIterations);
+            }
+        }).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        await Assert.That(maxObserved).IsEqualTo(1);
+        await Assert.That(completedIterations).IsEqualTo(workers * iterationsPerWorker);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Permit_Limit_Is_Never_Exceeded_Under_Contention()
+    {
+        const int maxCount = 4;
+        using var semaphore = new Semaphores.AsyncSemaphore(maxCount);
+
+        var holders = 0;
+        var maxObserved = 0;
+
+        const int workers = 16;
+        const int iterationsPerWorker = 2_000;
+
+        var tasks = Enumerable.Range(0, workers).Select(async _ =>
+        {
+            for (var i = 0; i < iterationsPerWorker; i++)
+            {
+                using var @lock = await semaphore.WaitAsync();
+
+                var current = Interlocked.Increment(ref holders);
+                InterlockedMax(ref maxObserved, current);
+                await Task.Yield();
+                Interlocked.Decrement(ref holders);
+            }
+        }).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        await Assert.That(maxObserved).IsLessThanOrEqualTo(maxCount);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(maxCount);
+    }
+
+    [Test]
+    public async Task Cancellation_Storm_Does_Not_Corrupt_Count()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        const int iterations = 500;
+
+        for (var i = 0; i < iterations; i++)
+        {
+            using var holder = await semaphore.WaitAsync();
+
+            using var cts = new CancellationTokenSource();
+
+            var waiterTask = semaphore.WaitAsync(cts.Token);
+
+            cts.Cancel();
+
+            try
+            {
+                using var _ = await waiterTask;
+            }
+            catch (OperationCanceledException)
+            {
+                // expected when cancellation won the race
+            }
+        }
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        using var final = await semaphore.WaitAsync();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Concurrent_Cancel_And_Release_Race_Does_Not_Corrupt_Count()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        const int iterations = 2_000;
+
+        for (var i = 0; i < iterations; i++)
+        {
+            var holder = await semaphore.WaitAsync();
+
+            using var cts = new CancellationTokenSource();
+
+            var waiterTask = semaphore.WaitAsync(cts.Token);
+
+            // Fire the release and the cancellation at the same time so the
+            // claim/cancel CAS race is exercised in both directions
+            var releaseTask = Task.Run(holder.Dispose);
+            var cancelTask = Task.Run(cts.Cancel);
+
+            await Task.WhenAll(releaseTask, cancelTask);
+
+            try
+            {
+                using var _ = await waiterTask;
+            }
+            catch (OperationCanceledException)
+            {
+                // cancellation won the race; the release settles the dead node
+            }
+        }
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        using var final = await semaphore.WaitAsync();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Timed_Out_Waiters_Do_Not_Block_Later_Waiters()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        using (await semaphore.WaitAsync())
+        {
+            // Queue up several waiters that all time out while the permit is held
+            var timedOutWaiters = Enumerable.Range(0, 5)
+                .Select(async _ =>
+                {
+                    try
+                    {
+                        using var held = await semaphore.WaitAsync(TimeSpan.FromMilliseconds(50));
+                        return false;
+                    }
+                    catch (TimeoutException)
+                    {
+                        return true;
+                    }
+                })
+                .ToArray();
+
+            var results = await Task.WhenAll(timedOutWaiters);
+            await Assert.That(results.All(timedOut => timedOut)).IsTrue();
+        }
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        using var @lock = await semaphore.WaitAsync();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Zero_Timeout_Throws_Immediately_When_Held()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+
+        using var @lock = await semaphore.WaitAsync();
+
+        await Assert.That(async () => await semaphore.WaitAsync(TimeSpan.Zero))
+            .ThrowsExactly<TimeoutException>();
+    }
+
+    private static void InterlockedMax(ref int location, int value)
+    {
+        int current;
+        do
+        {
+            current = Volatile.Read(ref location);
+        }
+        while (value > current && Interlocked.CompareExchange(ref location, value, current) != current);
+    }
+
     private Task DoSomething()
     {
         return Task.Delay(500);

--- a/AsyncSemaphore/AsyncSemaphore.cs
+++ b/AsyncSemaphore/AsyncSemaphore.cs
@@ -1,106 +1,409 @@
 #pragma warning disable SEM0001
 
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks.Sources;
 
 namespace Semaphores;
 
 public sealed class AsyncSemaphore : IAsyncSemaphore
 {
-    private readonly SemaphoreSlim _semaphoreSlim;
-    
+    /// <summary>
+    /// Positive values are available permits. Negative values are outstanding waiters
+    /// (each of which has enqueued, or is committed to enqueueing, a node in <see cref="_waiters"/>).
+    /// </summary>
+    private int _count;
+
+    private readonly ConcurrentQueue<Waiter> _waiters = new();
+    private readonly ConcurrentQueue<Waiter> _pool = new();
+
+    /// <summary>Single-slot fast cache in front of <see cref="_pool"/> for the common ping-pong case.</summary>
+    private Waiter? _pooledWaiter;
+
+    /// <summary>
+    /// Thread-local node cache tried before the shared pool: rent and return on the same thread
+    /// cost no interlocked operations at all. May hold a node last used by another semaphore;
+    /// nodes are re-owned on rent.
+    /// </summary>
+    [ThreadStatic]
+    private static Waiter? t_pooledWaiter;
+
+    private bool _disposed;
+
     public AsyncSemaphore(int maxCount)
     {
-        _semaphoreSlim = new(maxCount, maxCount);
+        if (maxCount < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCount), maxCount, "maxCount must be a positive integer.");
+        }
+
+        _count = maxCount;
     }
 
     /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask<AsyncSemaphoreReleaser> WaitAsync()
     {
-        var task = _semaphoreSlim.WaitAsync();
+        ThrowIfDisposed();
 
-        if (task.Status == TaskStatus.RanToCompletion)
+        if (TryAcquireFast())
         {
-            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(_semaphoreSlim));
+            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
         }
 
-        return AwaitAndReturn(task);
+        return EnqueueWaiter(Timeout.InfiniteTimeSpan, default);
     }
 
     /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask<AsyncSemaphoreReleaser> WaitAsync(TimeSpan timeout)
     {
-        var task = _semaphoreSlim.WaitAsync(timeout);
-
-        if (task.Status == TaskStatus.RanToCompletion)
-        {
-            return task.Result
-                ? new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(_semaphoreSlim))
-                : throw new TimeoutException($"The semaphore wait exceeded the timeout of {timeout}.");
-        }
-
-        return AwaitAndReturn(task, timeout);
+        return WaitAsync(timeout, CancellationToken.None);
     }
 
     /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask<AsyncSemaphoreReleaser> WaitAsync(CancellationToken cancellationToken)
     {
-        var task = _semaphoreSlim.WaitAsync(cancellationToken);
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
 
-        if (task.Status == TaskStatus.RanToCompletion)
+        if (TryAcquireFast())
         {
-            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(_semaphoreSlim));
+            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
         }
 
-        return AwaitAndReturn(task);
+        return EnqueueWaiter(Timeout.InfiniteTimeSpan, cancellationToken);
     }
 
     /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask<AsyncSemaphoreReleaser> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        var task = _semaphoreSlim.WaitAsync(timeout, cancellationToken);
+        ThrowIfDisposed();
+        ValidateTimeout(timeout);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        if (task.Status == TaskStatus.RanToCompletion)
+        if (TryAcquireFast())
         {
-            return task.Result
-                ? new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(_semaphoreSlim))
-                : throw new TimeoutException($"The semaphore wait exceeded the timeout of {timeout}.");
+            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
         }
 
-        return AwaitAndReturn(task, timeout);
+        return EnqueueWaiter(timeout, cancellationToken);
     }
 
-    private async ValueTask<AsyncSemaphoreReleaser> AwaitAndReturn(Task task)
+    /// <summary>
+    /// Optimistically takes a permit while the count is positive, without ever driving it negative.
+    /// Only the slow path's decrement creates waiter debt, which lets it rent its node up front and
+    /// keep the decrement-to-enqueue window (which a releaser spin-waits on) as small as possible.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryAcquireFast()
     {
-        await task.ConfigureAwait(false);
-        return new AsyncSemaphoreReleaser(_semaphoreSlim);
-    }
+        var count = Volatile.Read(ref _count);
 
-    private async ValueTask<AsyncSemaphoreReleaser> AwaitAndReturn(Task<bool> task, TimeSpan timeout)
-    {
-        var acquired = await task.ConfigureAwait(false);
-
-        if (!acquired)
+        while (count > 0)
         {
-            throw new TimeoutException($"The semaphore wait exceeded the timeout of {timeout}.");
+            var observed = Interlocked.CompareExchange(ref _count, count - 1, count);
+
+            if (observed == count)
+            {
+                return true;
+            }
+
+            count = observed;
         }
 
-        return new AsyncSemaphoreReleaser(_semaphoreSlim);
+        return false;
     }
 
     /// <inheritdoc />
     public int CurrentCount
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _semaphoreSlim.CurrentCount;
+        get
+        {
+            var count = Volatile.Read(ref _count);
+            return count > 0 ? count : 0;
+        }
     }
 
     /// <inheritdoc />
     public void Dispose()
     {
-        _semaphoreSlim.Dispose();
+        _disposed = true;
+    }
+
+    /// <summary>
+    /// Returns a permit. Called exactly once per successful acquisition, by <see cref="AsyncSemaphoreReleaser.Dispose"/>.
+    /// </summary>
+    internal void Release()
+    {
+        if (Interlocked.Increment(ref _count) <= 0)
+        {
+            ReleaseNextWaiter();
+        }
+    }
+
+    /// <summary>
+    /// The increment observed outstanding waiters, so this permit must be handed to exactly one of them.
+    /// The dequeue is the settlement token: whoever dequeues a node owns settling it, so a node
+    /// cancelled while queued is compensated here (its debt removed from the counter) and the permit
+    /// is re-deposited — going around again if the re-deposit still observes outstanding waiters.
+    /// </summary>
+    private void ReleaseNextWaiter()
+    {
+        while (true)
+        {
+            Waiter? waiter;
+            var spinner = default(SpinWait);
+
+            while (!_waiters.TryDequeue(out waiter))
+            {
+                // A decrement that goes negative is committed to enqueueing, so a node will appear.
+                spinner.SpinOnce();
+            }
+
+            if (waiter.TryClaim())
+            {
+                waiter.SetAcquired();
+                return;
+            }
+
+            // Dead (cancelled/timed-out) node: remove its debt and re-deposit the permit.
+            if (Interlocked.Increment(ref _count) > 0)
+            {
+                return;
+            }
+        }
+    }
+
+    private ValueTask<AsyncSemaphoreReleaser> EnqueueWaiter(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var waiter = t_pooledWaiter;
+
+        if (waiter is not null)
+        {
+            t_pooledWaiter = null;
+        }
+        else if ((waiter = Interlocked.Exchange(ref _pooledWaiter, null)) is null && !_pool.TryDequeue(out waiter))
+        {
+            waiter = new Waiter();
+        }
+
+        waiter.SetOwner(this);
+
+        var version = waiter.Version;
+
+        // The decrement is the commit point: a permit may have appeared since the fast path failed.
+        // The node is rented up front so the decrement-to-enqueue window a releaser spin-waits on
+        // stays as small as possible.
+        if (Interlocked.Decrement(ref _count) >= 0)
+        {
+            // Never armed, still clean.
+            ReturnWaiter(waiter);
+
+            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
+        }
+
+        // Arm cancellation before enqueueing: a claim can only happen after the enqueue, so the
+        // claimer always observes fully-armed timer/registration fields when cleaning them up.
+        // If cancellation fires first, the node is enqueued dead and settled by a later release.
+        if (timeout != Timeout.InfiniteTimeSpan || cancellationToken.CanBeCanceled)
+        {
+            waiter.ArmCancellation(timeout, cancellationToken);
+        }
+
+        _waiters.Enqueue(waiter);
+
+        return new ValueTask<AsyncSemaphoreReleaser>(waiter, version);
+    }
+
+    private void ReturnWaiter(Waiter waiter)
+    {
+        if (t_pooledWaiter is null)
+        {
+            // Un-own the node so a cached node does not root this semaphore from thread-local storage.
+            waiter.ClearOwner();
+            t_pooledWaiter = waiter;
+
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _pooledWaiter, waiter, null) != null)
+        {
+            _pool.Enqueue(waiter);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(AsyncSemaphore));
+        }
+    }
+
+    private static void ValidateTimeout(TimeSpan timeout)
+    {
+        var totalMilliseconds = (long)timeout.TotalMilliseconds;
+
+        if (totalMilliseconds < Timeout.Infinite || totalMilliseconds > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "The timeout must be -1 milliseconds (infinite) or a non-negative value <= Int32.MaxValue milliseconds.");
+        }
+    }
+
+    private sealed class Waiter : IValueTaskSource<AsyncSemaphoreReleaser>
+    {
+        private const int StatePending = 0;
+        private const int StateClaimed = 1;
+        private const int StateCancelled = 2;
+
+        private static readonly TimerCallback TimeoutCallback = static state => OnTimeout((Waiter)state!);
+        private static readonly Action<object?> CancellationCallback = static state => OnCancelled((Waiter)state!);
+
+        private AsyncSemaphore _owner = null!;
+
+        private ManualResetValueTaskSourceCore<AsyncSemaphoreReleaser> _core;
+        private int _state;
+        private bool _cancellable;
+        private Timer? _timeoutTimer;
+        private TimeSpan _timeout;
+        private CancellationTokenRegistration _cancellationRegistration;
+        private CancellationToken _cancellationToken;
+
+        public Waiter()
+        {
+            _core.RunContinuationsAsynchronously = true;
+        }
+
+        public short Version
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _core.Version;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetOwner(AsyncSemaphore owner)
+        {
+            _owner = owner;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ClearOwner()
+        {
+            _owner = null!;
+        }
+
+        public bool TryClaim()
+        {
+            // Only cancellation can race a claim, and the dequeue already guarantees a single
+            // claimer, so a waiter that can never be cancelled needs no interlocked claim.
+            return !_cancellable
+                || Interlocked.CompareExchange(ref _state, StateClaimed, StatePending) == StatePending;
+        }
+
+        public void SetAcquired()
+        {
+            if (_cancellable)
+            {
+                // The cancellation callbacks lose the CAS and return immediately, so these cannot deadlock.
+                _cancellationRegistration.Dispose();
+                _timeoutTimer?.Dispose();
+            }
+
+            _core.SetResult(new AsyncSemaphoreReleaser(_owner));
+        }
+
+        public void ArmCancellation(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            _cancellable = true;
+            _timeout = timeout;
+            _cancellationToken = cancellationToken;
+
+            if (timeout == TimeSpan.Zero)
+            {
+                OnTimeout(this);
+                return;
+            }
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                _cancellationRegistration = cancellationToken.Register(CancellationCallback, this);
+            }
+
+            if (timeout != Timeout.InfiniteTimeSpan && Volatile.Read(ref _state) == StatePending)
+            {
+                var timer = new Timer(TimeoutCallback, this, timeout, Timeout.InfiniteTimeSpan);
+
+                _timeoutTimer = timer;
+
+                // The cancellation callback may have fired before it could observe the timer.
+                if (Volatile.Read(ref _state) != StatePending)
+                {
+                    timer.Dispose();
+                }
+            }
+        }
+
+        private static void OnTimeout(Waiter waiter)
+        {
+            if (Interlocked.CompareExchange(ref waiter._state, StateCancelled, StatePending) != StatePending)
+            {
+                return;
+            }
+
+            waiter._cancellationRegistration.Dispose();
+            waiter._timeoutTimer?.Dispose();
+
+            waiter._core.SetException(new TimeoutException($"The semaphore wait exceeded the timeout of {waiter._timeout}."));
+        }
+
+        private static void OnCancelled(Waiter waiter)
+        {
+            if (Interlocked.CompareExchange(ref waiter._state, StateCancelled, StatePending) != StatePending)
+            {
+                return;
+            }
+
+            waiter._timeoutTimer?.Dispose();
+
+            waiter._core.SetException(new OperationCanceledException(waiter._cancellationToken));
+        }
+
+        public AsyncSemaphoreReleaser GetResult(short token)
+        {
+            // Throws for cancelled/timed-out waiters, which must not be pooled:
+            // their node is still queued until a release dequeues and settles it.
+            var result = _core.GetResult(token);
+
+            _core.Reset();
+
+            if (_cancellable)
+            {
+                _cancellable = false;
+                _state = StatePending;
+                _timeoutTimer = null;
+                _timeout = default;
+                _cancellationRegistration = default;
+                _cancellationToken = default;
+            }
+
+            _owner.ReturnWaiter(this);
+
+            return result;
+        }
+
+        public ValueTaskSourceStatus GetStatus(short token)
+        {
+            return _core.GetStatus(token);
+        }
+
+        public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        {
+            _core.OnCompleted(continuation, state, token, flags);
+        }
     }
 }

--- a/AsyncSemaphore/AsyncSemaphore.cs
+++ b/AsyncSemaphore/AsyncSemaphore.cs
@@ -379,14 +379,21 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
             // their node is still queued until a release dequeues and settles it.
             var result = _core.GetResult(token);
 
+            if (_timeoutTimer is not null)
+            {
+                // Timer.Dispose does not wait for an in-flight callback (unlike
+                // CancellationTokenRegistration.Dispose), so a stale OnTimeout may still
+                // hold this node. Dropping it instead of pooling leaves _state at
+                // StateClaimed, so the stale CAS fails without touching a recycled core.
+                return result;
+            }
+
             _core.Reset();
 
             if (_cancellable)
             {
                 _cancellable = false;
                 _state = StatePending;
-                _timeoutTimer = null;
-                _timeout = default;
                 _cancellationRegistration = default;
                 _cancellationToken = default;
             }

--- a/AsyncSemaphore/AsyncSemaphore.cs
+++ b/AsyncSemaphore/AsyncSemaphore.cs
@@ -89,6 +89,13 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
             return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
         }
 
+        if (timeout == TimeSpan.Zero)
+        {
+            // A zero timeout is a single attempt: fail here without renting a node, arming a timer,
+            // or creating waiter debt that a concurrent releaser would have to spin on and settle.
+            return new ValueTask<AsyncSemaphoreReleaser>(Task.FromException<AsyncSemaphoreReleaser>(CreateTimeoutException(timeout)));
+        }
+
         return EnqueueWaiter(timeout, cancellationToken);
     }
 
@@ -255,6 +262,11 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         }
     }
 
+    private static TimeoutException CreateTimeoutException(TimeSpan timeout)
+    {
+        return new TimeoutException($"The semaphore wait exceeded the timeout of {timeout}.");
+    }
+
     private sealed class Waiter : IValueTaskSource<AsyncSemaphoreReleaser>
     {
         private const int StatePending = 0;
@@ -323,12 +335,6 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
             _timeout = timeout;
             _cancellationToken = cancellationToken;
 
-            if (timeout == TimeSpan.Zero)
-            {
-                OnTimeout(this);
-                return;
-            }
-
             if (cancellationToken.CanBeCanceled)
             {
                 _cancellationRegistration = cancellationToken.Register(CancellationCallback, this);
@@ -358,7 +364,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
             waiter._cancellationRegistration.Dispose();
             waiter._timeoutTimer?.Dispose();
 
-            waiter._core.SetException(new TimeoutException($"The semaphore wait exceeded the timeout of {waiter._timeout}."));
+            waiter._core.SetException(CreateTimeoutException(waiter._timeout));
         }
 
         private static void OnCancelled(Waiter waiter)

--- a/AsyncSemaphore/AsyncSemaphore.csproj
+++ b/AsyncSemaphore/AsyncSemaphore.csproj
@@ -20,4 +20,8 @@
       <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8" />
+    </ItemGroup>
+
 </Project>

--- a/AsyncSemaphore/AsyncSemaphoreReleaser.cs
+++ b/AsyncSemaphore/AsyncSemaphoreReleaser.cs
@@ -15,6 +15,14 @@ public struct AsyncSemaphoreReleaser : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()
     {
-        Interlocked.Exchange(ref _semaphore, null)?.Release();
+        // A plain read-then-clear keeps a repeated Dispose of the same struct a no-op without paying for
+        // an interlocked exchange on every release; the interlocked publish is Release() itself.
+        var semaphore = _semaphore;
+
+        if (semaphore is not null)
+        {
+            _semaphore = null;
+            semaphore.Release();
+        }
     }
 }

--- a/AsyncSemaphore/AsyncSemaphoreReleaser.cs
+++ b/AsyncSemaphore/AsyncSemaphoreReleaser.cs
@@ -4,17 +4,17 @@ namespace Semaphores;
 
 public struct AsyncSemaphoreReleaser : IDisposable
 {
-    private SemaphoreSlim? _semaphoreSlim;
+    private AsyncSemaphore? _semaphore;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal AsyncSemaphoreReleaser(SemaphoreSlim semaphoreSlim)
+    internal AsyncSemaphoreReleaser(AsyncSemaphore semaphore)
     {
-        _semaphoreSlim = semaphoreSlim;
+        _semaphore = semaphore;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()
     {
-        Interlocked.Exchange(ref _semaphoreSlim, null)?.Release();
+        Interlocked.Exchange(ref _semaphore, null)?.Release();
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AsyncSemaphore is a .NET library that wraps `SemaphoreSlim` with automatic release via the `IDisposable` `using` pattern. It includes Roslyn analyzers (SEM0001–SEM0004) to enforce correct usage. The namespace is `Semaphores` (not `AsyncSemaphore`).
+AsyncSemaphore is a .NET library providing a custom lock-free async semaphore with automatic release via the `IDisposable` `using` pattern. It includes Roslyn analyzers (SEM0001–SEM0004) to enforce correct usage. The namespace is `Semaphores` (not `AsyncSemaphore`).
 
 ## Build & Test Commands
 
@@ -28,7 +28,7 @@ The CI pipeline (`AsyncSemaphore.Pipeline` project) orchestrates builds via Modu
 ## Architecture
 
 **Core library** (`AsyncSemaphore/`, namespace `Semaphores`):
-- `AsyncSemaphore` — sealed class implementing `IAsyncSemaphore`. Wraps a `SemaphoreSlim` and returns `AsyncSemaphoreReleaser` from `WaitAsync()` overloads.
+- `AsyncSemaphore` — sealed class implementing `IAsyncSemaphore`. Custom lock-free core (no `SemaphoreSlim`): an `Interlocked` counter where negative values represent queued waiters, a `ConcurrentQueue` of pooled `IValueTaskSource` waiter nodes (zero allocation, contended or not), and CAS-arbitrated cancellation/timeout. Cancelled nodes stay queued as dead entries; a release settles them via a compensation increment. Returns `AsyncSemaphoreReleaser` from `WaitAsync()` overloads.
 - `AsyncSemaphoreReleaser` — **struct** implementing `IDisposable`. Uses `Interlocked.Exchange` to guarantee single-release semantics. Zero-allocation design.
 - `IAsyncSemaphore` — interface for DI/mocking.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The CI pipeline (`AsyncSemaphore.Pipeline` project) orchestrates builds via Modu
 
 **Core library** (`AsyncSemaphore/`, namespace `Semaphores`):
 - `AsyncSemaphore` — sealed class implementing `IAsyncSemaphore`. Custom lock-free core (no `SemaphoreSlim`): an `Interlocked` counter where negative values represent queued waiters, a `ConcurrentQueue` of pooled `IValueTaskSource` waiter nodes (zero allocation, contended or not), and CAS-arbitrated cancellation/timeout. Cancelled nodes stay queued as dead entries; a release settles them via a compensation increment. Returns `AsyncSemaphoreReleaser` from `WaitAsync()` overloads.
-- `AsyncSemaphoreReleaser` — **struct** implementing `IDisposable`. Uses `Interlocked.Exchange` to guarantee single-release semantics. Zero-allocation design.
+- `AsyncSemaphoreReleaser` — **struct** implementing `IDisposable`. A plain read-then-clear of the semaphore field makes a repeated `Dispose` of the same struct a no-op with no interlocked cost (the interlocked publish is `Release()` itself; copies of the struct are not protected). Zero-allocation design.
 - `IAsyncSemaphore` — interface for DI/mocking.
 
 **Roslyn analyzers** (`AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers/`):

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # AsyncSemaphore
 
-A simple wrapper around a `SemaphoreSlim` featuring:
+A fast, allocation-free async semaphore featuring:
 - Automatic releasing without try/finally blocks by utilising the IDisposable `using` pattern
 - Guarantee that release can only be called once per `WaitAsync` call
+- A custom lock-free core that outperforms `SemaphoreSlim` (~2x faster uncontended, ~27% faster async handoff) and allocates zero bytes even for contended async waits (pooled `IValueTaskSource` waiters)
 - Analyzers to help you implement the desired pattern
 - An `IAsyncSemaphore` interface for if you need to mock
 
@@ -41,19 +42,30 @@ public async Task MyMethod()
 }
 ```
 
-Benchmarks and allocations can be seen below.
+## Performance
+
+AsyncSemaphore no longer wraps `SemaphoreSlim` — it has its own lock-free core:
+
+- **Uncontended waits** are a single interlocked operation (no monitor lock): ~2x faster than `SemaphoreSlim`.
+- **Contended async waits** use pooled (including thread-local cached) `IValueTaskSource` waiter nodes: ~27% faster handoff and zero bytes allocated per wait, versus 88 B per async waiter for `SemaphoreSlim`.
 
 ```
-BenchmarkDotNet v0.15.8, Linux Ubuntu 25.10 (Questing Quokka)
-12th Gen Intel Core i7-12700K 0.80GHz, 1 CPU, 20 logical and 12 physical cores
-.NET SDK 10.0.101
-  [Host]     : .NET 10.0.1 (10.0.1, 10.0.125.57005), X64 RyuJIT x86-64-v3
-  DefaultJob : .NET 10.0.1 (10.0.1, 10.0.125.57005), X64 RyuJIT x86-64-v3
+BenchmarkDotNet v0.15.8, Windows 11
+12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
+.NET SDK 10.0.400
+  [Host]     : .NET 10.0.11, X64 RyuJIT x86-64-v3
+  DefaultJob : .NET 10.0.11, X64 RyuJIT x86-64-v3
 ```
 
+| Method                      | Categories   | Mean      | Ratio | Allocated | Alloc Ratio |
+|---------------------------- |------------- |----------:|------:|----------:|------------:|
+| SemaphoreSlim               | Uncontended  |  29.73 ns |  1.00 |         - |          NA |
+| AsyncSemaphore              | Uncontended  |  15.16 ns |  0.51 |         - |          NA |
+|                             |              |           |       |           |             |
+| SemaphoreSlim_AsyncHandoff  | AsyncHandoff |  47.60 ns |  1.00 |      88 B |        1.00 |
+| AsyncSemaphore_AsyncHandoff | AsyncHandoff |  34.98 ns |  0.73 |         - |        0.00 |
+|                             |              |           |       |           |             |
+| SemaphoreSlim_Parallel      | Parallel     | 710.74 ns |  1.00 |      89 B |        1.00 |
+| AsyncSemaphore_Parallel     | Parallel     | 747.84 ns |  1.05 |         - |        0.01 |
 
-| Method                              | Mean     | Error    | StdDev   | Allocated |
-|------------------------------------ |---------:|---------:|---------:|----------:|
-| Raw_Semaphore_Slim                  | 29.95 ns | 0.054 ns | 0.048 ns |         - |
-| AsyncSemaphore_With_Inherited_Scope | 35.38 ns | 0.097 ns | 0.081 ns |         - |
-| AsyncSemaphore_With_Braced_Scope    | 35.72 ns | 0.247 ns | 0.231 ns |         - |
+`Uncontended` is a wait/release cycle with the permit available. `AsyncHandoff` measures handing the permit to a queued async waiter. `Parallel` is 4 workers hammering a single-permit semaphore with an `await Task.Yield()` inside the lock — AsyncSemaphore trades ~5% mean time there for fully allocation-free waits.


### PR DESCRIPTION
## Summary

Rewrites `AsyncSemaphore` from a `SemaphoreSlim` wrapper into a custom lock-free implementation. Public API is unchanged (the SEM analyzers key off `WaitAsync`/`AsyncSemaphoreReleaser`), but the internals are new:

- **Lock-free counter**: positive = available permits, negative = queued waiters. An uncontended wait is a single CAS and a release a single interlocked increment — no monitor lock on either side.
- **Zero-allocation contended waits**: waiters are pooled `IValueTaskSource` nodes (`ManualResetValueTaskSourceCore`) with a three-tier pool (thread-local cache → instance slot → `ConcurrentQueue`). `SemaphoreSlim` allocates a `TaskNode` (88 B) per async waiter.
- **Cancellation/timeout correctness**: a CAS on the node arbitrates claim vs cancel. Cancelled/timed-out nodes stay queued as dead entries; whoever dequeues a node owns settling it, and dead nodes are settled by a compensation increment — no lost or doubled permits.
- **Non-cancellable fast path**: plain `WaitAsync()` waiters skip the claim CAS entirely, since the queue dequeue already guarantees a single claimer.
- Zero `async` methods remain in the library — no state machines on any path.

## Benchmarks (i7-12700K, .NET 10)

| Category | SemaphoreSlim | AsyncSemaphore | Alloc (Slim vs ours) |
|---|---:|---:|---|
| Uncontended wait/release | 29.4 ns | **12.3 ns (0.42x)** | 0 vs 0 |
| Uncontended, with timeout | 29.1 ns | **15.6 ns (0.54x)** | 0 vs 0 |
| Uncontended, with cancellation token | 29.2 ns | **12.2 ns (0.42x)** | 0 vs 0 |
| Async handoff to queued waiter | 51.4 ns | **32.1 ns (0.62x)** | **88 B vs 0** |
| Async handoff, with timeout | 413 ns | **112 ns (0.27x)** | **472 B vs 144 B** |
| Async handoff, with cancellation token | 401 ns | **54 ns (0.14x)** | **376 B vs 0** |
| 4-worker parallel hammer | 693 ns | 712 ns (1.03x) | **89 B vs 1 B** |

The parallel case trades ~3% mean time for fully allocation-free waits; the gap is cache-line traffic vs SemaphoreSlim's single convoying lock. The 144 B on the timeout handoff is the `System.Threading.Timer` chain (`Timer` + `TimerHolder` + `TimerQueueTimer`); the waiter node itself is pooled.

Also includes a benchmark comparison of the internal waiter pool against [Reservoir](https://thomhurst.github.io/Reservoir/) (`PoolComparisonBenchmarks`): the specialized inline pool is ~2x faster on rent/return (3.7 ns vs 8.5 ns) and 11% faster on the integrated handoff path, and Reservoir targets .NET 10+ while the library ships netstandard2.0/net8/net9 — so the hand-rolled pool stays. Reservoir is referenced by the benchmark project only.

## Micro-optimisation pass

A second commit shaves the remaining fixed costs off the hot paths. Each change and why it is safe:

- **`AsyncSemaphoreReleaser.Dispose` drops `Interlocked.Exchange`** for a plain read-then-clear. A repeated `Dispose` of the same struct is still a no-op; struct copies were never protected either way, and `Release()` is already the interlocked publish. This is the biggest single win (19.2 → 12.7 ns uncontended).
- **`ValidateTimeout` is one unsigned range compare on `Ticks`**, equivalent to `SemaphoreSlim`'s `(long)timeout.TotalMilliseconds ∈ [-1, int.MaxValue]` at every boundary (including the truncation of e.g. -1.9 ms to -1), without the floating-point conversion.
- **Timer-armed waiters are pooled again.** The claimer disposes the timer with `Timer.DisposeAsync()` and keeps the node only when that completes synchronously. The runtime checks `_callbacksRunning` under the same lock `Fire` takes before running a callback, so a synchronous completion proves no stale `OnTimeout` can ever touch the node. If a callback *is* in flight the node is dropped as before. netstandard2.0 keeps drop-on-return.
- **`CancellationToken.UnsafeRegister`** instead of `Register` for token waiters — the callback is a CAS plus completing the core, so it needs no `ExecutionContext`. The `Timer` is built with the int-milliseconds constructor rather than the `TimeSpan` one.
- **Test-before-interlocked** on the single-slot pool in both rent and return, so an empty/full slot costs a read rather than a locked write on a shared line. `SetOwner` moves after the commit decrement so the "permit appeared" path never owns/un-owns the node.
- Throw/fault helpers are `NoInlining` so the inlined fast paths stay small; `Release` is `AggressiveInlining`.

Measured in a single run against a frozen copy of the pre-pass core (`AbBenchmarks`, old → new):

| Category | Before | After | Ratio |
|---|---:|---:|---:|
| Uncontended | 19.2 ns | 12.7 ns | 0.66 |
| Async handoff | 45.9 ns | 31.8 ns | 0.69 |
| Uncontended, with timeout | 19.0 ns | 16.0 ns | 0.85 |
| Async handoff, with timeout | 125 ns / 264 B | 113 ns / 144 B | 0.90 / 0.55 |
| Uncontended, with token | 15.8 ns | 15.0 ns | 0.95 |
| Async handoff, with token | 72.6 ns | 67.0 ns | 0.92 (noisy) |
| 4-worker parallel | 727 ns | 719 ns | 0.99 (noise) |

The A/B harness is kept in the benchmark project: `AsyncSemaphore.Benchmark/Baseline/` is a frozen snapshot of the core at 66ad5f7 and `AbBenchmarks` pits it against the working tree, so future changes can be measured without cross-run noise (`--filter "*AbBenchmarks*"`).

## Notes

- netstandard2.0 gains a `Microsoft.Bcl.AsyncInterfaces` dependency (for `ManualResetValueTaskSourceCore`).
- `Dispose()` now only blocks new waits (`ObjectDisposedException`) instead of throwing from in-flight releases.
- `AsyncSemaphoreReleaser.Dispose` no longer performs an interlocked exchange. Disposing the same struct instance twice is still a no-op; two threads racing to dispose the *same* struct location is not guarded (it never was for copies, and the SEM0004 analyzer already steers callers to `using`).
- Contract preserved: `TimeoutException` on timeout, plain `OperationCanceledException` on cancellation, FIFO among queued waiters, fast-path barging only when no live waiters are queued.

## Testing

- 51 unit tests pass, including stress tests: mutual-exclusion hammer (8×5k ops), permit-limit hammer (16×2k ops, maxCount 4), concurrent cancel-vs-release race (2,000 iterations), timeout storms, zero-timeout, FIFO ordering, exact wait accounting under cancel/timeout storms, mass wake-up chains, thread-local pool cross-talk between semaphores, and stale timer/cancellation callback no-op checks.
- 10 analyzer tests pass; full solution builds on all TFMs (netstandard2.0/net8/net9/net10).

https://claude.ai/code/session_01TViXpAa7SyrZH8x1tkSHVj
https://claude.ai/code/session_01F4Tqfsf1kQgs6vZeGygZU8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved semaphore performance across uncontended, asynchronous handoff, and parallel workloads.
  * Reduced allocations during asynchronous operations through internal pooling.

* **Reliability**
  * Strengthened cancellation, timeout, concurrency, and permit tracking behavior.
  * Improved disposal handling.

* **Documentation**
  * Updated performance results and implementation characteristics.

* **Testing**
  * Added extensive concurrency and contention stress coverage.
  * Expanded benchmarks for workload and pooling comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
