### PR TITLE
Guarantee at-most-once release for copied semaphore handles

### DIFF
--- a/AsyncSemaphore.UnitTests/ReleaserTests.cs
+++ b/AsyncSemaphore.UnitTests/ReleaserTests.cs
@@ -1,0 +1,68 @@
+// These tests deliberately copy and dispose handles to verify the ownership contract.
+#pragma warning disable SEM0001, SEM0002, SEM0003, SEM0004
+
+namespace AsyncSemaphore.UnitTests;
+
+public class ReleaserTests
+{
+    [Test]
+    public async Task Copied_Using_Handles_Release_Once()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        await Acquire();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+
+        async Task Acquire()
+        {
+            using var first = await semaphore.WaitAsync();
+            using var second = first;
+        }
+    }
+
+    [Test]
+    public async Task Concurrent_Boxed_Copies_Release_Once()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        var handle = await semaphore.WaitAsync();
+        var copies = Enumerable.Range(0, 32).Select(_ => (IDisposable)handle).ToArray();
+        await Task.WhenAll(copies.Select(copy => Task.Run(copy.Dispose))).WaitAsync(TimeSpan.FromSeconds(10));
+        handle.Dispose();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Stale_Copy_Cannot_Release_A_Later_Acquisition()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        var original = await semaphore.WaitAsync();
+        var stale = original;
+        var pending = semaphore.WaitAsync();
+        original.Dispose();
+
+        using var next = await pending;
+        stale.Dispose();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+        await Assert.That(async () => await semaphore.WaitAsync(TimeSpan.Zero))
+            .ThrowsExactly<TimeoutException>();
+    }
+
+    [Test]
+    public async Task Queued_Acquisition_Copies_Release_Once()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        var holder = await semaphore.WaitAsync();
+        var pending = semaphore.WaitAsync();
+        holder.Dispose();
+        var acquired = await pending;
+        var copy = acquired;
+        acquired.Dispose();
+        copy.Dispose();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public void Default_Handle_Disposal_Is_Harmless()
+    {
+        default(Semaphores.AsyncSemaphoreReleaser).Dispose();
+    }
+}

--- a/AsyncSemaphore/AsyncSemaphoreReleaser.cs
+++ b/AsyncSemaphore/AsyncSemaphoreReleaser.cs
@@ -2,27 +2,37 @@ using System.Runtime.CompilerServices;
 
 namespace Semaphores;
 
-public struct AsyncSemaphoreReleaser : IDisposable
+/// <summary>Releases an acquired permit at most once, including when the handle is copied or boxed.</summary>
+public readonly struct AsyncSemaphoreReleaser : IDisposable
 {
-    private AsyncSemaphore? _semaphore;
+    private readonly ReleaseState? _state;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal AsyncSemaphoreReleaser(AsyncSemaphore semaphore)
     {
-        _semaphore = semaphore;
+        _state = new ReleaseState(semaphore);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()
     {
-        // A plain read-then-clear keeps a repeated Dispose of the same struct a no-op without paying for
-        // an interlocked exchange on every release; the interlocked publish is Release() itself.
-        var semaphore = _semaphore;
+        _state?.Dispose();
+    }
 
-        if (semaphore is not null)
+    // Copies must share the release decision. This state cannot be pooled: an arbitrarily old
+    // copy may still be disposed after a later acquisition has started.
+    private sealed class ReleaseState
+    {
+        private AsyncSemaphore? _semaphore;
+
+        public ReleaseState(AsyncSemaphore semaphore)
         {
-            _semaphore = null;
-            semaphore.Release();
+            _semaphore = semaphore;
+        }
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _semaphore, null)?.Release();
         }
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@ The CI pipeline (`AsyncSemaphore.Pipeline` project) orchestrates builds via Modu
 ## Architecture
 
 **Core library** (`AsyncSemaphore/`, namespace `Semaphores`):
-- `AsyncSemaphore` — sealed class implementing `IAsyncSemaphore`. Custom lock-free core (no `SemaphoreSlim`): an `Interlocked` counter where negative values represent queued waiters, a `ConcurrentQueue` of pooled `IValueTaskSource` waiter nodes (zero allocation, contended or not), and CAS-arbitrated cancellation/timeout. Cancelled nodes stay queued as dead entries; a release settles them via a compensation increment. Returns `AsyncSemaphoreReleaser` from `WaitAsync()` overloads.
-- `AsyncSemaphoreReleaser` — **struct** implementing `IDisposable`. A plain read-then-clear of the semaphore field makes a repeated `Dispose` of the same struct a no-op with no interlocked cost (the interlocked publish is `Release()` itself; copies of the struct are not protected). Zero-allocation design.
+- `AsyncSemaphore` — sealed class implementing `IAsyncSemaphore`. Custom lock-free core (no `SemaphoreSlim`): an `Interlocked` counter where negative values represent queued waiters, a `ConcurrentQueue` of pooled `IValueTaskSource` waiter nodes (pooled waiter nodes; each acquisition still allocates release state), and CAS-arbitrated cancellation/timeout. Cancelled nodes stay queued as dead entries; a release settles them via a compensation increment. Returns `AsyncSemaphoreReleaser` from `WaitAsync()` overloads.
+- `AsyncSemaphoreReleaser` — readonly struct implementing `IDisposable`. Each acquisition allocates shared release state; an atomic exchange guarantees at-most-once release across copied, boxed, and concurrently disposed handles. Release state must not be pooled because stale copies can outlive later acquisitions.
 - `IAsyncSemaphore` — interface for DI/mocking.
 
 **Roslyn analyzers** (`AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers/`):

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # AsyncSemaphore
 
-A fast, allocation-free async semaphore featuring:
+An async semaphore featuring:
 - Automatic releasing without try/finally blocks by utilising the IDisposable `using` pattern
-- Guarantee that release can only be called once per `WaitAsync` call
-- A custom lock-free core that outperforms `SemaphoreSlim` (~2x faster uncontended, ~27% faster async handoff) and allocates zero bytes even for contended async waits (pooled `IValueTaskSource` waiters)
+- At-most-once release per acquisition, even when a handle is copied, boxed, or disposed concurrently
+- Pooled `IValueTaskSource` waiters to reduce allocation during contention
 - Analyzers to help you implement the desired pattern
 - An `IAsyncSemaphore` interface for if you need to mock
 
@@ -44,28 +44,14 @@ public async Task MyMethod()
 
 ## Performance
 
-AsyncSemaphore no longer wraps `SemaphoreSlim` — it has its own lock-free core:
+Successful acquisitions allocate one small shared release-state object. This ensures that all copies of a handle share the same atomic release decision. Default handles and repeated disposal are harmless; disposing a stale copy cannot release a later acquisition.
 
-- **Uncontended waits** are a single interlocked operation (no monitor lock): ~2x faster than `SemaphoreSlim`.
-- **Contended async waits** use pooled (including thread-local cached) `IValueTaskSource` waiter nodes: ~27% faster handoff and zero bytes allocated per wait, versus 88 B per async waiter for `SemaphoreSlim`.
+Contended waits reuse pooled `IValueTaskSource` nodes. Timed or cancellable waits may additionally allocate timers, registrations, and exceptions. The implementation is not allocation-free.
 
-```
-BenchmarkDotNet v0.15.8, Windows 11
-12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
-.NET SDK 10.0.400
-  [Host]     : .NET 10.0.11, X64 RyuJIT x86-64-v3
-  DefaultJob : .NET 10.0.11, X64 RyuJIT x86-64-v3
+Run the benchmarks for your workload and runtime:
+
+```shell
+dotnet run --project AsyncSemaphore.Benchmark -c Release -- --filter "*Benchmarks*"
 ```
 
-| Method                      | Categories   | Mean      | Ratio | Allocated | Alloc Ratio |
-|---------------------------- |------------- |----------:|------:|----------:|------------:|
-| SemaphoreSlim               | Uncontended  |  29.73 ns |  1.00 |         - |          NA |
-| AsyncSemaphore              | Uncontended  |  15.16 ns |  0.51 |         - |          NA |
-|                             |              |           |       |           |             |
-| SemaphoreSlim_AsyncHandoff  | AsyncHandoff |  47.60 ns |  1.00 |      88 B |        1.00 |
-| AsyncSemaphore_AsyncHandoff | AsyncHandoff |  34.98 ns |  0.73 |         - |        0.00 |
-|                             |              |           |       |           |             |
-| SemaphoreSlim_Parallel      | Parallel     | 710.74 ns |  1.00 |      89 B |        1.00 |
-| AsyncSemaphore_Parallel     | Parallel     | 747.84 ns |  1.05 |         - |        0.01 |
-
-`Uncontended` is a wait/release cycle with the permit available. `AsyncHandoff` measures handing the permit to a queued async waiter. `Parallel` is 4 workers hammering a single-permit semaphore with an `await Task.Yield()` inside the lock — AsyncSemaphore trades ~5% mean time there for fully allocation-free waits.
+Earlier measurements of the unprotected struct releaser do not represent the copy-safe implementation.


### PR DESCRIPTION
Copying a releaser into a second `using` variable previously released the same permit twice, allowing a semaphore constructed with one permit to reach `CurrentCount == 2`. Every copy now shares a release-state object whose atomic exchange permits only one release, including boxed handles, concurrent disposal, and stale copies disposed after another acquisition.

This deliberately adds one small allocation per successful acquisition (24 B measured on .NET 10 x64). Release state cannot safely be pooled because old copies may live indefinitely. Remove the allocation-free claims and historical benchmark table that described the unprotected implementation; document the tradeoff and preserve the public struct API and harmless default-handle disposal.

Validation:
- 56 unit tests passed, including five new regressions for copied using handles, concurrent boxed copies, queued acquisitions, stale handles, and default disposal.
- BenchmarkDotNet Dry and default uncontended runs completed; allocation measured 24 B/acquisition. Timing was noisy, so no new throughput claim is made.
- All five review fixes merged cleanly in a temporary integration worktree; the combined solution built and passed 256 tests.
