### PR TITLE
Fix analyzer NuGet packaging and test installed consumers

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           user: ${{ secrets.NUGET_USER }}
 
+      - name: Verify packed analyzers in consumer projects
+        shell: pwsh
+        run: ./scripts/Test-Packages.ps1
+
       - name: Run Pipeline
         run: dotnet run -c Release
         working-directory: "AsyncSemaphore.Pipeline"

--- a/AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers.csproj
+++ b/AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
 
@@ -13,6 +12,9 @@
         <AssemblyName>AsyncSemaphore.Analyzers</AssemblyName>
         
         <IsPackable>true</IsPackable>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+        <Description>Usage analyzers for AsyncSemaphore permit acquisition and release.</Description>
 
         <NoWarn>RS2003</NoWarn>
     </PropertyGroup>
@@ -22,8 +24,11 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/AsyncSemaphore/AsyncSemaphore.csproj
+++ b/AsyncSemaphore/AsyncSemaphore.csproj
@@ -7,13 +7,15 @@
         <Version>99</Version>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(GITHUB_ACTIONS)' != 'true'">
+    <ItemGroup>
         <ProjectReference Include="..\AsyncSemaphore.Analyzers\AsyncSemaphore.Analyzers\AsyncSemaphore.Analyzers.csproj"
-                          OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+                          OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all"/>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-        <ProjectReference Include="..\AsyncSemaphore.Analyzers\AsyncSemaphore.Analyzers\AsyncSemaphore.Analyzers.csproj" />
+    <!-- Ship the analyzer with the library so normal PackageReference consumers receive it. -->
+    <ItemGroup>
+        <None Include="../AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers/bin/$(Configuration)/netstandard2.0/AsyncSemaphore.Analyzers.dll"
+              Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/scripts/Test-Packages.ps1
+++ b/scripts/Test-Packages.ps1
@@ -1,0 +1,93 @@
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$smokeRoot = Join-Path ([IO.Path]::GetTempPath()) ('AsyncSemaphore-packages-' + [guid]::NewGuid().ToString('N'))
+$packages = Join-Path $smokeRoot 'packages'
+$version = '0.0.0-smoke.' + [guid]::NewGuid().ToString('N')
+New-Item -ItemType Directory -Path $packages -Force | Out-Null
+$escapedPackages = [Security.SecurityElement]::Escape($packages)
+$nugetConfig = Join-Path $smokeRoot 'NuGet.Config'
+@"
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="smoke" value="$escapedPackages" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"@ | Set-Content -LiteralPath $nugetConfig
+
+function Invoke-DotNet {
+    param([string[]] $Arguments)
+    & dotnet @Arguments
+    if ($LASTEXITCODE -ne 0) { throw "dotnet failed: $($Arguments -join ' ')" }
+}
+
+foreach ($project in @('AsyncSemaphore/AsyncSemaphore.csproj', 'AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers.csproj')) {
+    Invoke-DotNet -Arguments @('pack', (Join-Path $repoRoot $project), '-c', 'Release', '-o', $packages, "-p:PackageVersion=$version", '-p:GITHUB_ACTIONS=true')
+}
+
+foreach ($packageName in @('AsyncSemaphore', 'AsyncSemaphore.Analyzers')) {
+    $archive = [IO.Compression.ZipFile]::OpenRead((Join-Path $packages "$packageName.$version.nupkg"))
+    try {
+        if ($archive.Entries.FullName -notcontains 'analyzers/dotnet/cs/AsyncSemaphore.Analyzers.dll') {
+            throw "$packageName does not contain the analyzer in the compiler discovery directory."
+        }
+        if ($archive.Entries.FullName -contains 'lib/netstandard2.0/AsyncSemaphore.Analyzers.dll') {
+            throw "$packageName exposes the analyzer as a runtime library."
+        }
+        $reader = [IO.StreamReader]::new($archive.GetEntry("$packageName.nuspec").Open())
+        try { $manifest = $reader.ReadToEnd() } finally { $reader.Dispose() }
+        if ($manifest -match '<dependency id="Microsoft.CodeAnalysis') {
+            throw "$packageName leaks compiler dependencies to consumers."
+        }
+    }
+    finally { $archive.Dispose() }
+
+    $consumer = Join-Path $smokeRoot $packageName
+    New-Item -ItemType Directory -Path $consumer | Out-Null
+    $runtimeReference = ''
+    if ($packageName -eq 'AsyncSemaphore.Analyzers') {
+        $library = Join-Path $repoRoot 'AsyncSemaphore/bin/Release/net10.0/AsyncSemaphore.dll'
+        $escapedLibrary = [Security.SecurityElement]::Escape($library)
+        $runtimeReference = "<Reference Include=`"AsyncSemaphore`"><HintPath>$escapedLibrary</HintPath></Reference>"
+    }
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <WarningsAsErrors>SEM0001;SEM0002;SEM0003;SEM0004</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="$packageName" Version="$version" />
+    $runtimeReference
+  </ItemGroup>
+</Project>
+"@ | Set-Content -LiteralPath (Join-Path $consumer 'Consumer.csproj')
+    $source = Join-Path $consumer 'Usage.cs'
+    @'
+public class Usage
+{
+    public async System.Threading.Tasks.Task Run(Semaphores.AsyncSemaphore semaphore)
+    {
+        using var handle = await semaphore.WaitAsync();
+    }
+}
+'@ | Set-Content -LiteralPath $source
+    Invoke-DotNet -Arguments @('restore', $consumer, '--configfile', $nugetConfig)
+    Invoke-DotNet -Arguments @('build', $consumer, '-c', 'Release', '--no-restore')
+
+    @'
+public class Usage
+{
+    public void Run(Semaphores.AsyncSemaphore semaphore) { semaphore.WaitAsync(); }
+}
+'@ | Set-Content -LiteralPath $source
+    $output = & dotnet build $consumer -c Release --no-restore 2>&1 | Out-String
+    if ($LASTEXITCODE -eq 0 -or $output -notmatch 'error SEM0001') {
+        throw "The $packageName consumer did not enforce SEM0001:`n$output"
+    }
+    Write-Host "${packageName}: valid usage compiles and invalid usage fails with SEM0001."
+}
+Write-Host "Package smoke tests passed. Artifacts: $smokeRoot"
+# The last consumer build intentionally failed; report the smoke test's success to CI.
+exit 0


### PR DESCRIPTION
The analyzer package previously placed its DLL under `lib/netstandard2.0`, so NuGet consumers received a runtime library instead of compiler diagnostics. Package it under `analyzers/dotnet/cs`, and also embed that compiler asset in the main AsyncSemaphore package so its normal consumers receive the usage checks.

Remove the unused Workspaces dependency, keep Roslyn references private, and use the same analyzer project-reference metadata locally and in CI. The standalone analyzer package no longer exports compiler dependencies or a runtime assembly.

Add a CI smoke test that packs both packages with production metadata, inspects their manifests and layouts, and restores each into an isolated consumer. Valid usage must build; an unawaited wait must fail with SEM0001 promoted to an error. The script explicitly returns success after the expected failing build.

Validation:
- Both packed consumer smoke tests passed.
- All 10 existing analyzer tests passed.
- The combined solution with the other review fixes built and passed 256 tests; the package smoke test is also checked against the combined changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AsyncSemaphore packages now include analyzers for automatic compiler-time guidance.
  * Analyzer packages are packaged for discovery in compatible .NET consumer projects.

* **Bug Fixes**
  * Added automated validation to confirm packaged analyzers are correctly included, isolated from runtime libraries, and enforce expected diagnostics in consumer projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->