### PR TITLE
Track semaphore acquisitions into their using resources

### DIFF
--- a/AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers.Tests/AcquisitionTrackingTests.cs
+++ b/AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers.Tests/AcquisitionTrackingTests.cs
@@ -1,0 +1,98 @@
+using Semaphores.Analyzers;
+using Verifier = AsyncSemaphore.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<Semaphores.Analyzers.AsyncSemaphoreAnalyzer>;
+
+namespace AsyncSemaphore.Analyzers.Tests;
+
+public class AcquisitionTrackingTests
+{
+    [Test]
+    public async Task Unrelated_Await_And_Using_In_If_Body_Do_Not_Hide_Unawaited_Wait()
+    {
+        await Verifier.VerifyAnalyzerAsync(Wrap("""
+            {|#0:if (semaphore.WaitAsync().IsCompletedSuccessfully)
+            {
+                using var unrelated = new System.IO.MemoryStream();
+                await Task.Yield();
+            }|}
+            """), Verifier.Diagnostic(Rules.AwaitRule).WithLocation(0));
+    }
+
+    [Test]
+    public async Task Awaiting_Another_Argument_Does_Not_Consume_The_Wait()
+    {
+        await Verifier.VerifyAnalyzerAsync(Wrap("""
+            {|#0:Consume(semaphore.WaitAsync(), await Task.FromResult(1));|}
+            """), Verifier.Diagnostic(Rules.AwaitRule).WithLocation(0));
+    }
+
+    [Test]
+    public async Task Using_Another_Tuple_Element_Does_Not_Dispose_The_Handle()
+    {
+        await Verifier.VerifyAnalyzerAsync(Wrap("""
+            {|#0:using var unrelated = (await semaphore.WaitAsync(), new System.IO.MemoryStream()).Item2;|}
+            """), Verifier.Diagnostic(Rules.VariableAssignmentRule).WithLocation(0));
+    }
+
+    [Test]
+    public async Task Awaiting_A_Wrapper_Does_Not_Consume_The_Wait()
+    {
+        await Verifier.VerifyAnalyzerAsync(Wrap("""
+            {|#0:using var unrelated = await Ignore(semaphore.WaitAsync());|}
+            """), Verifier.Diagnostic(Rules.AwaitRule).WithLocation(0));
+    }
+
+    [Test]
+    [Arguments("using var handle = await semaphore.WaitAsync().ConfigureAwait(false);")]
+    [Arguments("using var handle = await semaphore.WaitAsync().AsTask().ConfigureAwait(false);")]
+    [Arguments("using (await semaphore.WaitAsync().ConfigureAwait(false)) { }")]
+    [Arguments("using (var handle = await semaphore.WaitAsync()) { }")]
+    [Arguments("using var handle = (await (semaphore.WaitAsync()));")]
+    [Arguments("using System.IDisposable handle = await semaphore.WaitAsync();")]
+    [Arguments("using var handle = System.DateTime.Now.Ticks > 0 ? await semaphore.WaitAsync() : default;")]
+    [Arguments("using var handle = System.DateTime.Now.Ticks switch { 0 => default, _ => await semaphore.WaitAsync() };")]
+    public async Task Direct_Resource_Ownership_Is_Accepted(string body)
+    {
+        await Verifier.VerifyAnalyzerAsync(Wrap(body));
+    }
+
+    [Test]
+    public async Task Expression_Bodied_Wait_Is_Not_Silently_Ignored()
+    {
+        await Verifier.VerifyAnalyzerAsync("""
+            using Semaphores;
+            public class Program
+            {
+                public object Leak(AsyncSemaphore semaphore) => {|#0:semaphore.WaitAsync()|};
+            }
+            """, Verifier.Diagnostic(Rules.AwaitRule).WithLocation(0));
+    }
+
+    [Test]
+    public async Task Nested_Unrelated_Namespace_Is_Not_A_Semaphore()
+    {
+        await Verifier.VerifyAnalyzerAsync("""
+            namespace Other.Semaphores
+            {
+                public class AsyncSemaphore { public void WaitAsync() { } }
+            }
+            public class Program
+            {
+                public void Main() { new Other.Semaphores.AsyncSemaphore().WaitAsync(); }
+            }
+            """);
+    }
+
+    private static string Wrap(string body) => $$"""
+        using Semaphores;
+        using System.Threading.Tasks;
+        public class Program
+        {
+            public async Task Main(AsyncSemaphore semaphore)
+            {
+                {{body}}
+            }
+            private void Consume(object value, int other) { }
+            private Task<System.IO.MemoryStream> Ignore(object value) => Task.FromResult(new System.IO.MemoryStream());
+        }
+        """;
+}

--- a/AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers/AsyncSemaphoreAnalyzer.cs
+++ b/AsyncSemaphore.Analyzers/AsyncSemaphore.Analyzers/AsyncSemaphoreAnalyzer.cs
@@ -11,9 +11,6 @@ namespace Semaphores.Analyzers;
 public class AsyncSemaphoreAnalyzer : DiagnosticAnalyzer
 {
     private const string CommonApiMethodName = "WaitAsync";
-    private const string CommonNamespace = "Semaphores";
-
-    private static readonly string[] ValidTypeNames = ["AsyncSemaphore", "IAsyncSemaphore"];
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(Rules.AwaitRule, Rules.VariableAssignmentRule, Rules.UsingKeywordRule);
@@ -47,62 +44,121 @@ public class AsyncSemaphoreAnalyzer : DiagnosticAnalyzer
 
         var receiverType = methodSymbol.ReceiverType;
 
-        if (!IsTargetType(receiverType))
+        if (!IsTargetType(receiverType, context.Compilation))
         {
             return;
         }
 
-        var parentStatement = GetParentStatement(invocationSyntax);
+        var location = (GetParentStatement(invocationSyntax) ?? invocationSyntax).GetLocation();
+        IOperation value = SkipWrappers(invocationOperation);
 
-        if (parentStatement is null)
+        // Only known task adapters preserve ownership of this acquisition. An await elsewhere
+        // in a condition, argument, or lambda does not consume this particular ValueTask.
+        while (value.Parent is IInvocationOperation adapter
+               && adapter.Instance == value
+               && IsTaskAdapter(adapter.TargetMethod, context.Compilation))
+        {
+            value = SkipWrappers(adapter);
+        }
+
+        if (value.Parent is not IAwaitOperation awaited || awaited.Operation != value)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rules.AwaitRule, location));
+            return;
+        }
+
+        var result = FollowHandleValue(awaited).Syntax;
+        // Parentheses may not have their own operation in every compiler version.
+        while (result.Parent is ParenthesizedExpressionSyntax)
+        {
+            result = result.Parent;
+        }
+
+        if (result.Parent is UsingStatementSyntax scoped && scoped.Expression == result)
         {
             return;
         }
 
-        var descendantNodes = parentStatement.DescendantNodes().ToList();
-        var descendantTokens = parentStatement.DescendantTokens().ToList();
-
-        if (!descendantNodes.Any(x => x is AwaitExpressionSyntax))
+        if (result.Parent is EqualsValueClauseSyntax initializer
+            && initializer.Parent is VariableDeclaratorSyntax declarator
+            && declarator.Parent is VariableDeclarationSyntax declaration)
         {
-            context.ReportDiagnostic(Diagnostic.Create(Rules.AwaitRule,
-                parentStatement.GetLocation()));
+            if (declaration.Parent is LocalDeclarationStatementSyntax local
+                && local.UsingKeyword.IsKind(SyntaxKind.UsingKeyword)
+                || declaration.Parent is UsingStatementSyntax)
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rules.UsingKeywordRule, location));
             return;
         }
 
-        if (descendantTokens.Any(x => x.IsKind(SyntaxKind.UsingKeyword)))
-        {
-            // We're correct disposing it on scope exit
-            return;
-        }
-
-        if (!descendantNodes.Any(x => x is VariableDeclarationSyntax))
-        {
-            context.ReportDiagnostic(Diagnostic.Create(Rules.VariableAssignmentRule,
-                parentStatement.GetLocation()));
-            return;
-        }
-
-        context.ReportDiagnostic(Diagnostic.Create(Rules.UsingKeywordRule,
-                parentStatement.GetLocation()));
+        context.ReportDiagnostic(Diagnostic.Create(Rules.VariableAssignmentRule, location));
     }
 
-    private static bool IsTargetType(ITypeSymbol? type)
+    private static IOperation SkipWrappers(IOperation value)
+    {
+        while (value.Parent is IConversionOperation { OperatorMethod: null }
+               or IParenthesizedOperation)
+        {
+            value = value.Parent;
+        }
+
+        return value;
+    }
+
+    private static IOperation FollowHandleValue(IOperation value)
+    {
+        while (true)
+        {
+            value = SkipWrappers(value);
+            if (value.Parent is IConditionalOperation conditional
+                && (conditional.WhenTrue == value || conditional.WhenFalse == value))
+            {
+                value = conditional;
+            }
+            else if (value.Parent is ISwitchExpressionArmOperation arm
+                     && arm.Value == value && arm.Parent is ISwitchExpressionOperation selection)
+            {
+                value = selection;
+            }
+            else
+            {
+                return value;
+            }
+        }
+    }
+
+    private static bool IsTaskAdapter(IMethodSymbol method, Compilation compilation)
+    {
+        var type = method.ContainingType.OriginalDefinition;
+        var valueTask = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
+        var task = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+        return (method.Name is "ConfigureAwait" or "AsTask"
+                && SymbolEqualityComparer.Default.Equals(type, valueTask))
+               || (method.Name == "ConfigureAwait"
+                   && SymbolEqualityComparer.Default.Equals(type, task));
+    }
+
+    private static bool IsTargetType(ITypeSymbol? type, Compilation compilation)
     {
         if (type is null)
         {
             return false;
         }
 
-        if (type.ContainingNamespace?.Name == CommonNamespace
-            && ValidTypeNames.Contains(type.Name))
+        var semaphore = compilation.GetTypeByMetadataName("Semaphores.AsyncSemaphore");
+        var semaphoreInterface = compilation.GetTypeByMetadataName("Semaphores.IAsyncSemaphore");
+        if (SymbolEqualityComparer.Default.Equals(type, semaphore)
+            || SymbolEqualityComparer.Default.Equals(type, semaphoreInterface))
         {
             return true;
         }
 
         foreach (var iface in type.AllInterfaces)
         {
-            if (iface.ContainingNamespace?.Name == CommonNamespace
-                && iface.Name == "IAsyncSemaphore")
+            if (SymbolEqualityComparer.Default.Equals(iface, semaphoreInterface))
             {
                 return true;
             }


### PR DESCRIPTION
An unrelated `await` and `using` anywhere in an enclosing statement could previously hide an unconsumed semaphore acquisition. Follow the actual WaitAsync operation through supported task adapters into its await and then into the using resource, instead of searching the entire statement for keywords.

Recognize ConfigureAwait, AsTask, parentheses, ordinary conversions, and conditional/switch resource selection. Report dropped handles and acquisitions passed into arbitrary wrappers, and check expression-bodied members that previously escaped analysis. Resolve semaphore types by their full compilation symbols so nested unrelated namespaces do not match.

Validation:
- All 24 analyzer tests passed (10 existing and 14 new cases).
- Regressions cover unrelated awaits/usings, tuple projection, wrapper calls, expression bodies, namespace collisions, and valid resource ownership patterns.
- Merged with the other four fixes in an integration worktree; the solution built and all 256 tests passed.

The analyzer continues to enforce direct acquisition/using patterns; it does not attempt interprocedural ownership analysis or track deferred ValueTasks across statements.
