### PR TITLE
Remove cancelled waiters immediately and bound the waiter pool

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
   workflow_dispatch:
     inputs:
       publish-packages:

--- a/AsyncSemaphore.UnitTests/ContentionTests.cs
+++ b/AsyncSemaphore.UnitTests/ContentionTests.cs
@@ -7,8 +7,8 @@ using TUnit.Assertions.Enums;
 namespace AsyncSemaphore.UnitTests;
 
 /// <summary>
-/// Stress tests targeting the lock-free core: the fast-path CAS, the decrement-to-enqueue
-/// commit window, the claim/cancel CAS, dead-node settlement, and the waiter node pools.
+/// Stress tests targeting the fast-path CAS, removable waiter queue,
+/// claim/cancel races, permit accounting, and the waiter node pools.
 /// </summary>
 public class ContentionTests
 {
@@ -343,7 +343,7 @@ public class ContentionTests
         cts.Cancel();
         await WhenAllWithTimeout(doomedWaiters);
 
-        // The dead nodes are still queued; releasing must settle them and still reach every live waiter
+        // Cancelled nodes have been removed; releasing must still reach every live waiter
         await Task.Run(holder.Dispose);
 
         await WhenAllWithTimeout(liveWaiters);

--- a/AsyncSemaphore.UnitTests/RetentionTests.cs
+++ b/AsyncSemaphore.UnitTests/RetentionTests.cs
@@ -1,0 +1,67 @@
+// Explicit ownership and reflection let these tests hold permits while checking retained waiters.
+#pragma warning disable SEM0001, SEM0002, SEM0003, SEM0004
+using System.Reflection;
+
+namespace AsyncSemaphore.UnitTests;
+
+public class RetentionTests
+{
+    [Test]
+    public async Task Cancelled_Waiters_Are_Removed_While_A_Permit_Remains_Held()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        var holder = await semaphore.WaitAsync();
+        var live = semaphore.WaitAsync();
+
+        for (var i = 0; i < 10_000; i++)
+        {
+            using var cts = new CancellationTokenSource();
+            var pending = semaphore.WaitAsync(cts.Token);
+            cts.Cancel();
+            await Assert.That(async () => await pending).ThrowsExactly<OperationCanceledException>();
+        }
+
+        // A live waiter ahead of cancelled nodes prevents head-only cleanup from passing.
+        await Assert.That(QueueCount(semaphore, "_waiters")).IsEqualTo(1);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(0);
+        holder.Dispose();
+        using (await live.AsTask().WaitAsync(TimeSpan.FromSeconds(10))) { }
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Timed_Out_Waiters_Are_Removed_While_A_Permit_Remains_Held()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        using var holder = await semaphore.WaitAsync();
+        var waits = Enumerable.Range(0, 100).Select(_ => semaphore.WaitAsync(TimeSpan.FromMilliseconds(10)).AsTask()).ToArray();
+        foreach (var wait in waits)
+        {
+            await Assert.That(async () => await wait.WaitAsync(TimeSpan.FromSeconds(10))).ThrowsExactly<TimeoutException>();
+        }
+        await Assert.That(QueueCount(semaphore, "_waiters")).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Burst_Contention_Does_Not_Leave_An_Unbounded_Pool()
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        var holder = await semaphore.WaitAsync();
+        var waits = Enumerable.Range(0, 2_000).Select(_ => semaphore.WaitAsync()).ToArray();
+        holder.Dispose();
+        foreach (var wait in waits)
+        {
+            // Direct consumption keeps returns on this thread, filling the shared overflow pool.
+            using (await wait) { }
+        }
+        await Assert.That(QueueCount(semaphore, "_pool")).IsLessThanOrEqualTo(256);
+        await Assert.That(QueueCount(semaphore, "_waiters")).IsEqualTo(0);
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    private static int QueueCount(Semaphores.AsyncSemaphore semaphore, string name)
+    {
+        var queue = typeof(Semaphores.AsyncSemaphore).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(semaphore)!;
+        return (int)queue.GetType().GetProperty("Count")!.GetValue(queue)!;
+    }
+}

--- a/AsyncSemaphore/AsyncSemaphore.cs
+++ b/AsyncSemaphore/AsyncSemaphore.cs
@@ -19,12 +19,15 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
     /// <summary>
     /// Positive values are available permits. Negative values are outstanding waiters
-    /// (each of which has enqueued, or is committed to enqueueing, a node in <see cref="_waiters"/>).
+    /// protected by <see cref="_waitersLock"/> while adding, claiming, or cancelling nodes.
     /// </summary>
     private int _count;
 
-    private readonly ConcurrentQueue<Waiter> _waiters = new();
+    private readonly object _waitersLock = new();
+    private readonly LinkedList<Waiter> _waiters = new();
     private readonly ConcurrentQueue<Waiter> _pool = new();
+    private const int MaxPooledWaiters = 256;
+    private int _pooledCount;
 
     /// <summary>Single-slot fast cache in front of <see cref="_pool"/> for the common ping-pong case.</summary>
     private Waiter? _pooledWaiter;
@@ -110,8 +113,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
     /// <summary>
     /// Optimistically takes a permit while the count is positive, without ever driving it negative.
-    /// Only the slow path's decrement creates waiter debt, which lets it rent its node up front and
-    /// keep the decrement-to-enqueue window (which a releaser spin-waits on) as small as possible.
+    /// Only the slow path creates waiter debt, while holding the removable queue's lock.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryAcquireFast()
@@ -156,74 +158,104 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void Release()
     {
-        if (Interlocked.Increment(ref _count) <= 0)
+        var count = Volatile.Read(ref _count);
+        while (count >= 0)
         {
-            ReleaseNextWaiter();
+            var observed = Interlocked.CompareExchange(ref _count, count + 1, count);
+            if (observed == count)
+            {
+                return;
+            }
+
+            count = observed;
         }
+
+        ReleaseNextWaiter();
     }
 
     /// <summary>
-    /// The increment observed outstanding waiters, so this permit must be handed to exactly one of them.
-    /// The dequeue is the settlement token: whoever dequeues a node owns settling it, so a node
-    /// cancelled while queued is compensated here (its debt removed from the counter) and the permit
-    /// is re-deposited — going around again if the re-deposit still observes outstanding waiters.
+    /// Serialize handoff with removal so cancellation cannot remove a node after a release has
+    /// committed to handing it a permit. Completion and registration disposal happen outside the lock.
     /// </summary>
     private void ReleaseNextWaiter()
     {
-        while (true)
+        Waiter? waiter = null;
+        lock (_waitersLock)
         {
-            Waiter? waiter;
-            var spinner = default(SpinWait);
-
-            while (!_waiters.TryDequeue(out waiter))
+            if (Interlocked.Increment(ref _count) <= 0)
             {
-                // A decrement that goes negative is committed to enqueueing, so a node will appear.
-                spinner.SpinOnce();
-            }
-
-            if (waiter.TryClaim())
-            {
-                waiter.SetAcquired();
-                return;
-            }
-
-            // Dead (cancelled/timed-out) node: remove its debt and re-deposit the permit.
-            if (Interlocked.Increment(ref _count) > 0)
-            {
-                return;
+                waiter = _waiters.First!.Value;
+                _waiters.RemoveFirst();
+                waiter.TryClaim();
             }
         }
+
+        waiter?.SetAcquired();
     }
 
     private ValueTask<AsyncSemaphoreReleaser> EnqueueWaiter(TimeSpan timeout, CancellationToken cancellationToken)
     {
-        // The node is rented up front so the decrement-to-enqueue window a releaser spin-waits on
-        // stays as small as possible.
         var waiter = RentWaiter();
         var version = waiter.Version;
+        var acquired = false;
 
-        // The decrement is the commit point: a permit may have appeared since the fast path failed.
-        if (Interlocked.Decrement(ref _count) >= 0)
+        lock (_waitersLock)
         {
-            // Never owned or armed, still clean.
-            ReturnWaiter(waiter);
+            if (TryAcquireFast())
+            {
+                ReturnWaiter(waiter);
+                return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
+            }
 
-            return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
+            waiter.SetOwner(this);
+
+            // Arm before creating debt. Synchronous token cancellation may reenter the lock;
+            // foreign callbacks wait until fields and queue membership are fully initialized.
+            if (timeout != Timeout.InfiniteTimeSpan || cancellationToken.CanBeCanceled)
+            {
+                waiter.ArmCancellation(timeout, cancellationToken);
+            }
+
+            if (!waiter.IsCancelled)
+            {
+                // An uncontended release can publish a permit even while we hold this lock.
+                if (Interlocked.Decrement(ref _count) >= 0)
+                {
+                    waiter.TryClaim();
+                    acquired = true;
+                }
+                else
+                {
+                    _waiters.AddLast(waiter.QueueNode);
+                }
+            }
         }
 
-        waiter.SetOwner(this);
-
-        // Arm cancellation before enqueueing: a claim can only happen after the enqueue, so the
-        // claimer always observes fully-armed timer/registration fields when cleaning them up.
-        // If cancellation fires first, the node is enqueued dead and settled by a later release.
-        if (timeout != Timeout.InfiniteTimeSpan || cancellationToken.CanBeCanceled)
+        if (acquired)
         {
-            waiter.ArmCancellation(timeout, cancellationToken);
+            waiter.SetAcquired();
         }
-
-        _waiters.Enqueue(waiter);
 
         return new ValueTask<AsyncSemaphoreReleaser>(waiter, version);
+    }
+
+    private bool TryCancelWaiter(Waiter waiter)
+    {
+        lock (_waitersLock)
+        {
+            if (!waiter.TryCancel())
+            {
+                return false;
+            }
+
+            if (waiter.QueueNode.List is not null)
+            {
+                _waiters.Remove(waiter.QueueNode);
+                Interlocked.Increment(ref _count);
+            }
+
+            return true;
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -245,7 +277,13 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
             return waiter;
         }
 
-        return _pool.TryDequeue(out waiter) ? waiter : new Waiter();
+        if (_pool.TryDequeue(out waiter))
+        {
+            Interlocked.Decrement(ref _pooledCount);
+            return waiter;
+        }
+
+        return new Waiter();
     }
 
     private void ReturnWaiter(Waiter waiter)
@@ -263,7 +301,14 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         if (Volatile.Read(ref _pooledWaiter) is not null
             || Interlocked.CompareExchange(ref _pooledWaiter, waiter, null) is not null)
         {
-            _pool.Enqueue(waiter);
+            if (Interlocked.Increment(ref _pooledCount) <= MaxPooledWaiters)
+            {
+                _pool.Enqueue(waiter);
+            }
+            else
+            {
+                Interlocked.Decrement(ref _pooledCount);
+            }
         }
     }
 
@@ -336,7 +381,13 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         public Waiter()
         {
             _core.RunContinuationsAsynchronously = true;
+            QueueNode = new LinkedListNode<Waiter>(this);
         }
+
+        public LinkedListNode<Waiter> QueueNode { get; }
+        public bool IsCancelled => _state == StateCancelled;
+
+        public bool TryCancel() => Interlocked.CompareExchange(ref _state, StateCancelled, StatePending) == StatePending;
 
         public short Version
         {
@@ -426,7 +477,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
         private static void OnTimeout(Waiter waiter)
         {
-            if (Interlocked.CompareExchange(ref waiter._state, StateCancelled, StatePending) != StatePending)
+            if (!waiter._owner.TryCancelWaiter(waiter))
             {
                 return;
             }
@@ -439,7 +490,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
         private static void OnCancelled(Waiter waiter)
         {
-            if (Interlocked.CompareExchange(ref waiter._state, StateCancelled, StatePending) != StatePending)
+            if (!waiter._owner.TryCancelWaiter(waiter))
             {
                 return;
             }
@@ -451,8 +502,8 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
 
         public AsyncSemaphoreReleaser GetResult(short token)
         {
-            // Throws for cancelled/timed-out waiters, which must not be pooled:
-            // their node is still queued until a release dequeues and settles it.
+            // Cancelled/timed-out nodes are unlinked immediately, but must not be pooled:
+            // cancellation/timer callbacks may still be using their fields after completion.
             var result = _core.GetResult(token);
 
             if (_timeoutTimer is not null)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AsyncSemaphore is a .NET library providing a custom lock-free async semaphore with automatic release via the `IDisposable` `using` pattern. It includes Roslyn analyzers (SEM0001–SEM0004) to enforce correct usage. The namespace is `Semaphores` (not `AsyncSemaphore`).
+AsyncSemaphore is a .NET library providing a custom async semaphore with atomic fast paths and a removable waiter queue with automatic release via the `IDisposable` `using` pattern. It includes Roslyn analyzers (SEM0001–SEM0004) to enforce correct usage. The namespace is `Semaphores` (not `AsyncSemaphore`).
 
 ## Build & Test Commands
 
@@ -28,7 +28,7 @@ The CI pipeline (`AsyncSemaphore.Pipeline` project) orchestrates builds via Modu
 ## Architecture
 
 **Core library** (`AsyncSemaphore/`, namespace `Semaphores`):
-- `AsyncSemaphore` — sealed class implementing `IAsyncSemaphore`. Custom lock-free core (no `SemaphoreSlim`): an `Interlocked` counter where negative values represent queued waiters, a `ConcurrentQueue` of pooled `IValueTaskSource` waiter nodes (pooled waiter nodes; each acquisition still allocates release state), and CAS-arbitrated cancellation/timeout. Cancelled nodes stay queued as dead entries; a release settles them via a compensation increment. Returns `AsyncSemaphoreReleaser` from `WaitAsync()` overloads.
+- `AsyncSemaphore` — sealed class implementing `IAsyncSemaphore`. Uncontended waits/releases use a CAS counter. Contended enqueue, handoff, and cancellation share a lock protecting a linked waiter queue. Cancellation removes its own node and debt immediately. Successful waits reuse waiter nodes with a bounded shared pool (256), a single shared cache slot, and one thread-local slot per thread. Acquisitions allocate shared release state.
 - `AsyncSemaphoreReleaser` — readonly struct implementing `IDisposable`. Each acquisition allocates shared release state; an atomic exchange guarantees at-most-once release across copied, boxed, and concurrently disposed handles. Release state must not be pooled because stale copies can outlive later acquisitions.
 - `IAsyncSemaphore` — interface for DI/mocking.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Successful acquisitions allocate one small shared release-state object. This ens
 
 Contended waits reuse pooled `IValueTaskSource` nodes. Timed or cancellable waits may additionally allocate timers, registrations, and exceptions. The implementation is not allocation-free.
 
+Uncontended acquisition and release use atomic counter operations. Contended waits use a removable queue protected by a lock, so cancellation and timeout remove waiters immediately even when a permit remains held. The shared overflow pool retains at most 256 waiter nodes, in addition to one shared cache slot and one thread-local slot per thread.
+
 Run the benchmarks for your workload and runtime:
 
 ```shell


### PR DESCRIPTION
Cancelled and timed-out waiters previously stayed queued until a holder released a permit. A long-running holder could therefore retain arbitrarily many completed waits, including nodes behind another live waiter.

Use a removable linked queue guarded on the contended path. Enqueue, claim, and cancellation removal now settle queue membership and counter debt together; cancellation/timeout removes its own node immediately. Uncontended acquisition and release retain atomic counter fast paths. Callback cleanup and acquired completion happen outside the queue lock to avoid disposal deadlocks. Cancelled nodes remain ineligible for reuse while callbacks may still reference them.

Bound the shared overflow pool to 256 nodes, in addition to the shared single-slot cache and one thread-local slot per thread. Update implementation documentation and allow CI on PRs targeting feature branches so this stacked PR is tested.

Validation:
- 59 unit tests passed, including retention after 10,000 cancellations behind a live waiter, timeout retention, and a 2,000-waiter pool burst.
- The library built for netstandard2.0, net8.0, net9.0, and net10.0.
- Combined with the contract-test PR, all runtime and netstandard test runs passed as part of the 256-test integration run.
- BenchmarkDotNet Dry and Short handoff runs completed. Short-run means on .NET 10 x64 were 123.4 ns / 24 B for AsyncSemaphore versus 108.4 ns / 88 B for SemaphoreSlim. The short run has wide confidence intervals; treat this as an indicative cost of immediate removal, not a stable performance guarantee.

This PR is based on `fix/releaser-copy-safety`; merge the copied-releaser PR first, then retarget this PR to main.
