### PR TITLE
Test all semaphore targets and document timeout and disposal contracts

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-dotnet@v6.0.0
         with:
           dotnet-version: |
+            8.0.x
             9.0.x
             10.0.x
       - name: NuGet login

--- a/AsyncSemaphore.NetStandard.UnitTests/AsyncSemaphore.NetStandard.UnitTests.csproj
+++ b/AsyncSemaphore.NetStandard.UnitTests/AsyncSemaphore.NetStandard.UnitTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);LIBRARY_NETSTANDARD2_0</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="TUnit" Version="1.66.16" />
+    <!-- Restore otherwise chooses the nearest net10.0 project target's dependency graph. -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8" />
+    <ProjectReference Include="../AsyncSemaphore/AsyncSemaphore.csproj"
+                      SetTargetFramework="TargetFramework=netstandard2.0"
+                      SkipGetTargetFrameworkProperties="true" />
+    <Compile Include="../AsyncSemaphore.UnitTests/*.cs" Link="%(Filename)%(Extension)" />
+  </ItemGroup>
+</Project>

--- a/AsyncSemaphore.UnitTests/AsyncSemaphore.UnitTests.csproj
+++ b/AsyncSemaphore.UnitTests/AsyncSemaphore.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>exe</OutputType>

--- a/AsyncSemaphore.UnitTests/ContentionTests.cs
+++ b/AsyncSemaphore.UnitTests/ContentionTests.cs
@@ -168,7 +168,7 @@ public class ContentionTests
             }
         })).ToArray();
 
-        await allQueued.AllQueued;
+        await allQueued.AllQueued.WaitAsync(StressTimeout);
         ReleaseAll(initialHolders);
 
         await WhenAllWithTimeout(tasks);
@@ -559,7 +559,7 @@ public class ContentionTests
             }
         })).ToArray();
 
-        await allQueued.AllQueued;
+        await allQueued.AllQueued.WaitAsync(StressTimeout);
         ReleaseAll(holderA);
         ReleaseAll(holderB);
 
@@ -612,7 +612,7 @@ public class ContentionTests
             }
         })).ToArray();
 
-        await allQueued.AllQueued;
+        await allQueued.AllQueued.WaitAsync(StressTimeout);
         ReleaseAll(outerHolders);
         ReleaseAll(innerHolders);
 

--- a/AsyncSemaphore.UnitTests/ContractTests.cs
+++ b/AsyncSemaphore.UnitTests/ContractTests.cs
@@ -1,0 +1,99 @@
+#pragma warning disable SEM0001, SEM0002, SEM0003, SEM0004
+using System.Reflection;
+using System.Runtime.Versioning;
+
+namespace AsyncSemaphore.UnitTests;
+
+public class ContractTests
+{
+    [Test]
+    public async Task Tests_Load_The_Intended_Library_Target()
+    {
+        var framework = typeof(Semaphores.AsyncSemaphore).Assembly.GetCustomAttribute<TargetFrameworkAttribute>()!.FrameworkName;
+#if LIBRARY_NETSTANDARD2_0
+        await Assert.That(framework).IsEqualTo(".NETStandard,Version=v2.0");
+#else
+        var testFramework = typeof(ContractTests).Assembly.GetCustomAttribute<TargetFrameworkAttribute>()!.FrameworkName;
+        await Assert.That(framework).IsEqualTo(testFramework);
+#endif
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(-1)]
+    public async Task Constructor_Requires_A_Positive_Count(int count)
+    {
+        await Assert.That(() => new Semaphores.AsyncSemaphore(count)).ThrowsExactly<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    [Arguments(-20_000L)]
+    [Arguments(21_474_836_480_000L)]
+    [Arguments(long.MinValue)]
+    [Arguments(long.MaxValue)]
+    public async Task Invalid_Timeout_Throws_Without_Consuming_A_Permit(long ticks)
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        await Assert.That(() => { _ = semaphore.WaitAsync(TimeSpan.FromTicks(ticks)); }).ThrowsExactly<ArgumentOutOfRangeException>();
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(-19_999L)]
+    [Arguments(-10_000L)]
+    [Arguments(21_474_836_479_999L)]
+    public async Task Accepted_Timeout_Boundaries_Acquire_On_The_Queued_Path(long ticks)
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        var holder = await semaphore.WaitAsync();
+        var pending = semaphore.WaitAsync(TimeSpan.FromTicks(ticks));
+        await Assert.That(pending.IsCompleted).IsFalse();
+        holder.Dispose();
+        using (await pending.AsTask().WaitAsync(TimeSpan.FromSeconds(10))) { }
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [Arguments(-9_999L)]
+    [Arguments(-1L)]
+    [Arguments(0L)]
+    [Arguments(1L)]
+    [Arguments(9_999L)]
+    public async Task Fractional_Zero_Timeout_Is_An_Immediate_Attempt(long ticks)
+    {
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        using var holder = await semaphore.WaitAsync();
+        var pending = semaphore.WaitAsync(TimeSpan.FromTicks(ticks));
+        await Assert.That(pending.IsCompleted).IsTrue();
+        await Assert.That(async () => await pending).ThrowsExactly<TimeoutException>();
+    }
+
+    [Test]
+    public async Task Dispose_Rejects_All_New_Waits_But_Allows_Existing_Handoff()
+    {
+        var semaphore = new Semaphores.AsyncSemaphore(1);
+        var holder = await semaphore.WaitAsync();
+        var pending = semaphore.WaitAsync();
+        semaphore.Dispose();
+        semaphore.Dispose();
+        await Assert.That(() => { _ = semaphore.WaitAsync(); }).ThrowsExactly<ObjectDisposedException>();
+        await Assert.That(() => { _ = semaphore.WaitAsync(CancellationToken.None); }).ThrowsExactly<ObjectDisposedException>();
+        await Assert.That(() => { _ = semaphore.WaitAsync(TimeSpan.Zero); }).ThrowsExactly<ObjectDisposedException>();
+        await Assert.That(() => { _ = semaphore.WaitAsync(TimeSpan.Zero, CancellationToken.None); }).ThrowsExactly<ObjectDisposedException>();
+        holder.Dispose();
+        using (await pending.AsTask().WaitAsync(TimeSpan.FromSeconds(10))) { }
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Pending_Wait_Remains_Cancellable_After_Disposal()
+    {
+        var semaphore = new Semaphores.AsyncSemaphore(1);
+        using var holder = await semaphore.WaitAsync();
+        using var cts = new CancellationTokenSource();
+        var pending = semaphore.WaitAsync(cts.Token);
+        semaphore.Dispose();
+        cts.Cancel();
+        await Assert.That(async () => await pending).ThrowsExactly<OperationCanceledException>();
+    }
+}

--- a/AsyncSemaphore.UnitTests/Tests.cs
+++ b/AsyncSemaphore.UnitTests/Tests.cs
@@ -5,58 +5,43 @@ public class Tests
     [Test]
     public async Task Can_Enter_Immediately()
     {
-        var semaphore = new Semaphores.AsyncSemaphore(1);
-        
-        var time = await Measure(async () =>
-        {
-            using var @lock = await semaphore.WaitAsync();
-        });
-        
-        await Assert.That(time).IsLessThan(TimeSpan.FromMilliseconds(100));
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        var pending = semaphore.WaitAsync();
+        await Assert.That(pending.IsCompletedSuccessfully).IsTrue();
+        using var handle = await pending;
     }
-    
-    [Test]
-    [MethodDataSource(nameof(LoopCounts))]
-    public async Task WaitsForPreviousSemaphore(int loopCount)
-    {
-        var semaphore = new Semaphores.AsyncSemaphore(1);
-        
-        var time = await Measure(async () =>
-        {
-            for (var i = 0; i < loopCount; i++)
-            {
-                using var @lock = await semaphore.WaitAsync();
-                await DoSomething();
-            }
-        });
 
-        await Assert.That(time).IsGreaterThan(TimeSpan.FromMilliseconds(500 * (loopCount - 1)));
-    }
-    
     [Test]
-    [MethodDataSource(nameof(LoopCounts))]
-    public async Task WaitsForPreviousSemaphore_Even_When_Exception_Thrown(int loopCount)
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Queued_Waiter_Enters_After_Previous_Scope_Exits(bool throwInsideScope)
     {
-        var semaphore = new Semaphores.AsyncSemaphore(1);
-        
-        var time = await Measure(async () =>
+        using var semaphore = new Semaphores.AsyncSemaphore(1);
+        var entered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var exit = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = Hold();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var pending = semaphore.WaitAsync();
+        await Assert.That(pending.IsCompleted).IsFalse();
+        exit.SetResult(true);
+        using (await pending.AsTask().WaitAsync(TimeSpan.FromSeconds(10))) { }
+        if (throwInsideScope)
         {
-            for (var i = 0; i < loopCount; i++)
-            {
-                try
-                {
-                    using var @lock = await semaphore.WaitAsync();
-                    await DoSomething();
-                    throw new Exception();
-                }
-                catch
-                {
-                    // ignored
-                }
-            }
-        });
+            await Assert.That(async () => await first).ThrowsExactly<InvalidOperationException>();
+        }
+        else
+        {
+            await first;
+        }
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(1);
 
-        await Assert.That(time).IsGreaterThan(TimeSpan.FromMilliseconds(500 * (loopCount - 1)));
+        async Task Hold()
+        {
+            using var handle = await semaphore.WaitAsync();
+            entered.SetResult(true);
+            await exit.Task;
+            if (throwInsideScope) { throw new InvalidOperationException(); }
+        }
     }
 
     [Test]
@@ -307,19 +292,4 @@ public class Tests
         while (value > current && Interlocked.CompareExchange(ref location, value, current) != current);
     }
 
-    private Task DoSomething()
-    {
-        return Task.Delay(500);
-    }
-
-    public static IEnumerable<int> LoopCounts() => Enumerable.Range(1, 10);
-
-    private async Task<TimeSpan> Measure(Func<Task> func)
-    {
-        var start = DateTime.Now;
-
-        await func();
-
-        return DateTime.Now - start;
-    } 
 }

--- a/AsyncSemaphore.sln
+++ b/AsyncSemaphore.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncSemaphore.Analyzers.Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncSemaphore.Benchmark", "AsyncSemaphore.Benchmark\AsyncSemaphore.Benchmark.csproj", "{F8AC3ADD-4193-431D-853C-510CD061B1E5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncSemaphore.NetStandard.UnitTests", "AsyncSemaphore.NetStandard.UnitTests\AsyncSemaphore.NetStandard.UnitTests.csproj", "{EE0DA5EF-0225-4EDB-B890-24B595936794}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,5 +44,9 @@ Global
 		{F8AC3ADD-4193-431D-853C-510CD061B1E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F8AC3ADD-4193-431D-853C-510CD061B1E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F8AC3ADD-4193-431D-853C-510CD061B1E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE0DA5EF-0225-4EDB-B890-24B595936794}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE0DA5EF-0225-4EDB-B890-24B595936794}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE0DA5EF-0225-4EDB-B890-24B595936794}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE0DA5EF-0225-4EDB-B890-24B595936794}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/AsyncSemaphore/AsyncSemaphore.cs
+++ b/AsyncSemaphore/AsyncSemaphore.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks.Sources;
 
 namespace Semaphores;
 
+/// <summary>An asynchronous semaphore whose acquired permits are released by disposing their handles.</summary>
 public sealed class AsyncSemaphore : IAsyncSemaphore
 {
     /// <summary>
@@ -37,7 +38,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
     [ThreadStatic]
     private static Waiter? t_pooledWaiter;
 
-    private bool _disposed;
+    private volatile bool _disposed;
 
     public AsyncSemaphore(int maxCount)
     {
@@ -98,7 +99,7 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
             return new ValueTask<AsyncSemaphoreReleaser>(new AsyncSemaphoreReleaser(this));
         }
 
-        if (timeout == TimeSpan.Zero)
+        if (timeout.Ticks / TimeSpan.TicksPerMillisecond == 0)
         {
             // A zero timeout is a single attempt: fail here without renting a node, arming a timer,
             // or creating waiter debt that a concurrent releaser would have to spin on and settle.
@@ -144,7 +145,9 @@ public sealed class AsyncSemaphore : IAsyncSemaphore
         }
     }
 
-    /// <inheritdoc />
+    /// <summary>Prevents subsequent waits from acquiring permits.</summary>
+    /// <remarks>Existing acquisitions can still release, and pending waits can still acquire,
+    /// time out, or be cancelled. Disposal does not cancel or drain pending waits.</remarks>
     public void Dispose()
     {
         _disposed = true;

--- a/AsyncSemaphore/IAsyncSemaphore.cs
+++ b/AsyncSemaphore/IAsyncSemaphore.cs
@@ -2,18 +2,37 @@
 
 public interface IAsyncSemaphore : IDisposable
 {
-    /// <inheritdoc cref="SemaphoreSlim.WaitAsync()"/>
+    /// <summary>Acquires a permit, waiting asynchronously if none is available.</summary>
+    /// <returns>A handle that releases the permit when disposed. Consume the returned ValueTask only once.</returns>
+    /// <exception cref="ObjectDisposedException">The semaphore has been disposed.</exception>
     ValueTask<AsyncSemaphoreReleaser> WaitAsync();
 
-    /// <inheritdoc cref="SemaphoreSlim.WaitAsync(TimeSpan)"/>
+    /// <summary>Acquires a permit within the specified timeout.</summary>
+    /// <param name="timeout">Truncated to whole milliseconds: -1 waits indefinitely, 0 attempts immediate acquisition,
+    /// and positive values wait up to that duration. The truncated value must not exceed Int32.MaxValue.</param>
+    /// <returns>A handle that releases the permit when disposed. Consume the returned ValueTask only once.</returns>
+    /// <exception cref="TimeoutException">No permit was acquired before the timeout elapsed.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The truncated timeout is outside [-1, Int32.MaxValue] milliseconds.</exception>
+    /// <exception cref="ObjectDisposedException">The semaphore has been disposed.</exception>
     ValueTask<AsyncSemaphoreReleaser> WaitAsync(TimeSpan timeout);
 
-    /// <inheritdoc cref="SemaphoreSlim.WaitAsync(CancellationToken)"/>
+    /// <summary>Acquires a permit, allowing cancellation while waiting.</summary>
+    /// <param name="cancellationToken">Cancels acquisition. Cancellation after acquisition does not release the permit.</param>
+    /// <returns>A handle that releases the permit when disposed. Consume the returned ValueTask only once.</returns>
+    /// <exception cref="OperationCanceledException">Cancellation won before acquisition. An already cancelled token throws synchronously.</exception>
+    /// <exception cref="ObjectDisposedException">The semaphore has been disposed.</exception>
     ValueTask<AsyncSemaphoreReleaser> WaitAsync(CancellationToken cancellationToken);
 
-    /// <inheritdoc cref="SemaphoreSlim.WaitAsync(TimeSpan, CancellationToken)"/>
+    /// <summary>Acquires a permit within the specified timeout, allowing cancellation while waiting.</summary>
+    /// <param name="timeout">Truncated to whole milliseconds in [-1, Int32.MaxValue]; -1 waits indefinitely and 0 attempts immediate acquisition.</param>
+    /// <param name="cancellationToken">Cancels acquisition. Cancellation after acquisition does not release the permit.</param>
+    /// <returns>A handle that releases the permit when disposed. Consume the returned ValueTask only once.</returns>
+    /// <exception cref="TimeoutException">No permit was acquired before the timeout elapsed.</exception>
+    /// <exception cref="OperationCanceledException">Cancellation won before acquisition. An already cancelled token throws synchronously.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The truncated timeout is outside [-1, Int32.MaxValue] milliseconds.</exception>
+    /// <exception cref="ObjectDisposedException">The semaphore has been disposed.</exception>
     ValueTask<AsyncSemaphoreReleaser> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken);
 
-    /// <inheritdoc cref="SemaphoreSlim.CurrentCount"/>
+    /// <summary>Gets a snapshot of the available permit count, never less than zero.</summary>
     int CurrentCount { get; }
 }


### PR DESCRIPTION
The runtime tests exercised only the net10.0 library, and older delay-based tests did not actually coordinate competing waiters. Run the shared suite on .NET 8, 9, and 10, and add a separate .NET 10 host that explicitly references the netstandard2.0 library to exercise its distinct timer/cancellation implementation. An assembly-target assertion prevents accidental testing of the nearest modern target. Install .NET 8 in CI and include the fallback harness in the solution and existing test-project discovery.

Replace sequential wall-clock tests with coordinated holders and queued waiters, including exceptional scope exit. Add constructor, timeout-boundary, cancellation-after-disposal, and disposal/handoff coverage, and bound contention setup gates. Boundary testing also fixes fractional timeouts that truncate to zero: they now attempt acquisition immediately instead of scheduling a timer. Publish disposal visibility with a volatile flag.

Replace inherited SemaphoreSlim wait documentation with the actual releaser/ValueTask, TimeoutException, cancellation, timeout-truncation, and disposal contracts. Disposal rejects new waits while existing acquisitions and pending waits can finish.

Validation:
- 150 tests passed across .NET 8/9/10 (50 per target).
- 50 tests passed against the actual netstandard2.0 assembly in the fallback harness.
- All five review fixes merged cleanly; the combined solution built and passed 256 tests, including copied-handle and retention regressions across all four library targets.
